### PR TITLE
Skip CI for auto release commit

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -65,7 +65,7 @@ jobs:
           poetry version patch
           git add pyproject.toml
           new_version=`poetry version`
-          git commit -m "chore(release): ${new_version}"
+          git commit -m "[skip ci] chore(release): ${new_version}"
           git push -f
       - name: Publish to PyPI
         run: |


### PR DESCRIPTION
Avoid running github workflows like `pdoc` when the commit is the auto-release commit (where the only change is bumping version number). 