### PR TITLE
Documentation improvements

### DIFF
--- a/examples/post-processings/farmland-coverage/farmland-coverage.ipynb
+++ b/examples/post-processings/farmland-coverage/farmland-coverage.ipynb
@@ -7,7 +7,13 @@
    "source": [
     "## Farmland Coverage Analysis\n",
     "\n",
-    "This notebook demonstrates how to use a VisualPrompting model to analyze the area coverage of different types of land or structures on satellite images."
+    "This notebook demonstrates how to use a VisualPrompting model to analyze the area coverage of different types of land or structures on satellite images.\n",
+    "\n",
+    "In particular, we are going to show you:\n",
+    "\n",
+    "1. How to use the `Predictor` class to extract the segmentation mask\n",
+    "2. How to visualize the segmentation mask\n",
+    "3. How to extract the percentage pixel coverage and visualize it in a pie chart"
    ]
   },
   {
@@ -27,43 +33,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Obtaining file:///Users/asia/work/repos/landingai-python-v1\n",
-      "  Installing build dependencies ... \u001b[?25ldone\n",
-      "\u001b[?25h  Checking if build backend supports build_editable ... \u001b[?25ldone\n",
-      "\u001b[?25h  Getting requirements to build editable ... \u001b[?25ldone\n",
-      "\u001b[?25h  Preparing editable metadata (pyproject.toml) ... \u001b[?25ldone\n",
-      "\u001b[?25hRequirement already satisfied: requests in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from landingai==0.0.10) (2.30.0)\n",
-      "Requirement already satisfied: pydantic[dotenv] in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from landingai==0.0.10) (1.10.7)\n",
-      "Requirement already satisfied: segmentation-mask-overlay in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from landingai==0.0.10) (0.3.4)\n",
-      "Requirement already satisfied: numpy>=1.21.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from landingai==0.0.10) (1.24.3)\n",
-      "Requirement already satisfied: opencv-python-headless>=4.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from landingai==0.0.10) (4.7.0.72)\n",
-      "Requirement already satisfied: pillow>=9.1.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from landingai==0.0.10) (9.5.0)\n",
-      "Requirement already satisfied: typing-extensions>=4.2.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from pydantic[dotenv]->landingai==0.0.10) (4.5.0)\n",
-      "Requirement already satisfied: python-dotenv>=0.10.4 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from pydantic[dotenv]->landingai==0.0.10) (1.0.0)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from requests->landingai==0.0.10) (3.1.0)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from requests->landingai==0.0.10) (2.0.2)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from requests->landingai==0.0.10) (2023.5.7)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from requests->landingai==0.0.10) (3.4)\n",
-      "Requirement already satisfied: matplotlib>=3.4.2 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from segmentation-mask-overlay->landingai==0.0.10) (3.7.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (4.39.4)\n",
-      "Requirement already satisfied: pyparsing>=2.3.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (3.0.9)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (1.4.4)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (2.8.2)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (1.0.7)\n",
-      "Requirement already satisfied: packaging>=20.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (23.1)\n",
-      "Requirement already satisfied: cycler>=0.10 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (0.11.0)\n",
-      "Requirement already satisfied: six>=1.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-nSG-IZmK-py3.10/lib/python3.10/site-packages (from python-dateutil>=2.7->matplotlib>=3.4.2->segmentation-mask-overlay->landingai==0.0.10) (1.16.0)\n",
-      "Building wheels for collected packages: landingai\n",
-      "  Building editable for landingai (pyproject.toml) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for landingai: filename=landingai-0.0.10-py3-none-any.whl size=3080 sha256=fa262449681d53debe8f1f3bc18d24a2afd9fb66e869d85596d4b1f77fa621f0\n",
-      "  Stored in directory: /private/var/folders/cv/kdkz6y_55z1blffx_f42w6zh0000gn/T/pip-ephem-wheel-cache-zphht5s5/wheels/70/1a/3e/d40cb628b35404dc22d558368398d25e27b7bd5e02545ec547\n",
-      "Successfully built landingai\n",
-      "Installing collected packages: landingai\n",
-      "  Attempting uninstall: landingai\n",
-      "    Found existing installation: landingai 0.0.10\n",
-      "    Uninstalling landingai-0.0.10:\n",
-      "      Successfully uninstalled landingai-0.0.10\n",
-      "Successfully installed landingai-0.0.10\n",
+      "Requirement already satisfied: landingai in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (0.0.13)\n",
+      "Requirement already satisfied: pillow>=9.1.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (9.5.0)\n",
+      "Requirement already satisfied: numpy>=1.21.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (1.24.3)\n",
+      "Requirement already satisfied: pydantic[dotenv] in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (1.10.7)\n",
+      "Requirement already satisfied: segmentation-mask-overlay in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (0.3.4)\n",
+      "Requirement already satisfied: opencv-python-headless>=4.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (4.7.0.72)\n",
+      "Requirement already satisfied: requests in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (2.31.0)\n",
+      "Requirement already satisfied: bbox-visualizer in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (0.1.0)\n",
+      "Requirement already satisfied: typing-extensions>=4.2.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from pydantic[dotenv]->landingai) (4.5.0)\n",
+      "Requirement already satisfied: python-dotenv>=0.10.4 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from pydantic[dotenv]->landingai) (1.0.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (3.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (1.26.16)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (2.1.1)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (2023.5.7)\n",
+      "Requirement already satisfied: matplotlib>=3.4.2 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from segmentation-mask-overlay->landingai) (3.7.1)\n",
+      "Requirement already satisfied: cycler>=0.10 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (0.11.0)\n",
+      "Requirement already satisfied: contourpy>=1.0.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.0.7)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (4.39.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (2.8.2)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.4.4)\n",
+      "Requirement already satisfied: packaging>=20.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (23.1)\n",
+      "Requirement already satisfied: pyparsing>=2.3.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (3.0.9)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from python-dateutil>=2.7->matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.16.0)\n",
       "\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip available: \u001b[0m\u001b[31;49m22.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.1.2\u001b[0m\n",
       "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
@@ -71,10 +63,7 @@
     }
    ],
    "source": [
-    "!pip install landingai\n",
-    "\n",
-    "# If you have cloned the repo and you are in the local repo, you can install the `landingai` library like below:\n",
-    "# !pip install -e ../../../"
+    "!pip install landingai"
    ]
   },
   {
@@ -82,12 +71,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load images"
+    "### Prerequisite: Deployed Model\n",
+    "\n",
+    "Before doing the coverage analsis, we have already trained a VisualPrompting model on LandingLens platform, and deployed the model to a web endpoint via [CloudDeployment](https://support.landing.ai/landinglens/docs/cloud-deployment).\n",
+    "\n",
+    "In below cell, we set the endpint id associated with this model and the api_key and api_secret of our user."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#@title Set the following variables as needed for your setup\n",
+    "api_key = \"zm7ml657kh9a370k9liluxg9heuoufv\"\n",
+    "api_secret = \"1ccnesqy4em8dc32k2h2cu5kovdcd6palepaw4ugly6ttfl2fylu340x7ecja0\"\n",
+    "endpoint_id = \"16049857-67bf-4c60-b20b-899741adbfdf\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load images\n",
+    "\n",
+    "Here we load three testing images for the coverage analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,12 +121,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example image"
+    "### Example image\n",
+    "\n",
+    "Let's take a look at one of the testing images.\n",
+    "\n",
+    "The model is trained to segment four classes:\n",
+    "\n",
+    "1. Green field\n",
+    "2. Brown field\n",
+    "3. Trees\n",
+    "4. Structure"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -134,19 +158,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run inferences"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#@title Set the following variables as needed for your setup\n",
-    "api_key = \"zm7ml657kh9a370k9liluxg9heuoufv\"\n",
-    "api_secret = \"1ccnesqy4em8dc32k2h2cu5kovdcd6palepaw4ugly6ttfl2fylu340x7ecja0\"\n",
-    "endpoint_id = \"16049857-67bf-4c60-b20b-899741adbfdf\""
+    "### Run inferences\n",
+    "\n",
+    "In below cell, we use the `Predictor` to get the predicted segmentation masks for each image.\n",
+    "The predictor returns a list of `SegmentationPrediction` instances for each image.\n",
+    "\n",
+    "We collect all the prediction results into a list for further processing. "
    ]
   },
   {
@@ -164,10 +181,17 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example image with prediction"
+    "### Example image with prediction\n",
+    "\n",
+    "Before moving forward, it's helpful to do a sanity check to see if the prediction result looks reasonable to you.  \n",
+    "\n",
+    "To do that, we get the predictions of a single image, and visualize it like below.\n",
+    "\n",
+    "NOTE: for this demo, we didn't spend time on improving model performance, so the segmentation mask may not be perfect."
    ]
   },
   {
@@ -194,21 +218,47 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Post-processing: compute the coverage of each class"
+    "### Post-processing: compute the coverage of each class\n",
+    "\n",
+    "Now we have collected a list of predictions, i.e. segmentation masks, we can call the `segmentation_class_pixel_coverage()` API to calculate the percentage of the pixel coverage of each class over all the images.\n",
+    "\n",
+    "The output, i.e. `coverage`,  is a dictionary where the key is the predicted class index, and the value is a tuple of coverage percentage and the predicted class name.\n",
+    "\n",
+    "The coverage percentage is calculated as follow:\n",
+    "\n",
+    "`(number of predicted pixels for this class) / (total number of pixels)`\n",
+    "\n",
+    "NOTE: alternatively, we can also get the absolute coverage value, i.e. the number predicted pixels for each class, by doing `segmentation_class_pixel_coverage(predictions, coverage_type='absolute')`. See the API doc in `postprocess.py` for more details."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1: (0.21799135208129883, 'green field'),\n",
+       " 2: (0.0003237724304199219, 'brown field'),\n",
+       " 3: (0.03159618377685547, 'structure'),\n",
+       " 4: (3.552436828613281e-05, 'trees')}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from landingai.postprocess import segmentation_class_pixel_coverage\n",
     "\n",
-    "coverage = segmentation_class_pixel_coverage(predictions)"
+    "coverage = segmentation_class_pixel_coverage(predictions)\n",
+    "coverage"
    ]
   },
   {
@@ -216,7 +266,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Visualize the predictions in a pie chart"
+    "### Visualize the predictions in a pie chart\n",
+    "\n",
+    "Now we have the coverage data."
    ]
   },
   {

--- a/examples/webcam-collab-notebook/webcam-collab-notebook.ipynb
+++ b/examples/webcam-collab-notebook/webcam-collab-notebook.ipynb
@@ -13,7 +13,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 1,
       "metadata": {
         "id": "NY4RZzXqZdKm"
       },
@@ -28,7 +28,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 2,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -41,28 +41,36 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Requirement already satisfied: landingai in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (0.0.13)\n",
-            "Requirement already satisfied: numpy>=1.21.0 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from landingai) (1.24.3)\n",
-            "Requirement already satisfied: opencv-python-headless>=4.5 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from landingai) (4.7.0.72)\n",
-            "Requirement already satisfied: pillow>=9.1.1 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from landingai) (9.5.0)\n",
-            "Requirement already satisfied: pydantic[dotenv] in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from landingai) (1.10.7)\n",
-            "Requirement already satisfied: requests in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from landingai) (2.30.0)\n",
-            "Requirement already satisfied: segmentation-mask-overlay in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from landingai) (0.3.4)\n",
-            "Requirement already satisfied: typing-extensions>=4.2.0 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from pydantic[dotenv]->landingai) (4.5.0)\n",
-            "Requirement already satisfied: python-dotenv>=0.10.4 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from pydantic[dotenv]->landingai) (1.0.0)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from requests->landingai) (3.1.0)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from requests->landingai) (3.4)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from requests->landingai) (2.0.2)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from requests->landingai) (2023.5.7)\n",
-            "Requirement already satisfied: matplotlib>=3.4.2 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from segmentation-mask-overlay->landingai) (3.7.1)\n",
-            "Requirement already satisfied: contourpy>=1.0.1 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.0.7)\n",
-            "Requirement already satisfied: cycler>=0.10 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (0.11.0)\n",
-            "Requirement already satisfied: fonttools>=4.22.0 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (4.39.4)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.4.4)\n",
-            "Requirement already satisfied: packaging>=20.0 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (23.1)\n",
-            "Requirement already satisfied: pyparsing>=2.3.1 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (3.0.9)\n",
-            "Requirement already satisfied: python-dateutil>=2.7 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (2.8.2)\n",
-            "Requirement already satisfied: six>=1.5 in /Users/matias/repos/landingai-python/.venv/lib/python3.11/site-packages (from python-dateutil>=2.7->matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.16.0)\n",
+            "Found existing installation: Pillow 9.5.0\n",
+            "Uninstalling Pillow-9.5.0:\n",
+            "  Successfully uninstalled Pillow-9.5.0\n",
+            "Note: you may need to restart the kernel to use updated packages.\n",
+            "Requirement already satisfied: landingai in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (0.0.13)\n",
+            "Requirement already satisfied: bbox-visualizer in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (0.1.0)\n",
+            "Requirement already satisfied: requests in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (2.31.0)\n",
+            "Requirement already satisfied: pydantic[dotenv] in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (1.10.7)\n",
+            "Requirement already satisfied: numpy>=1.21.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (1.24.3)\n",
+            "Collecting pillow>=9.1.1\n",
+            "  Using cached Pillow-9.5.0-cp310-cp310-macosx_11_0_arm64.whl (3.1 MB)\n",
+            "Requirement already satisfied: segmentation-mask-overlay in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (0.3.4)\n",
+            "Requirement already satisfied: opencv-python-headless>=4.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from landingai) (4.7.0.72)\n",
+            "Requirement already satisfied: typing-extensions>=4.2.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from pydantic[dotenv]->landingai) (4.5.0)\n",
+            "Requirement already satisfied: python-dotenv>=0.10.4 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from pydantic[dotenv]->landingai) (1.0.0)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (1.26.16)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (2.1.1)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (2023.5.7)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from requests->landingai) (3.4)\n",
+            "Requirement already satisfied: matplotlib>=3.4.2 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from segmentation-mask-overlay->landingai) (3.7.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.7 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (2.8.2)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.0.7)\n",
+            "Requirement already satisfied: cycler>=0.10 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (0.11.0)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (4.39.4)\n",
+            "Requirement already satisfied: packaging>=20.0 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (23.1)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.4.4)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (3.0.9)\n",
+            "Requirement already satisfied: six>=1.5 in /Users/asia/Library/Caches/pypoetry/virtualenvs/landingai-_c3uY8Dq-py3.10/lib/python3.10/site-packages (from python-dateutil>=2.7->matplotlib>=3.4.2->segmentation-mask-overlay->landingai) (1.16.0)\n",
+            "Installing collected packages: pillow\n",
+            "Successfully installed pillow-9.5.0\n",
             "\n",
             "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip available: \u001b[0m\u001b[31;49m22.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.1.2\u001b[0m\n",
             "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
@@ -71,7 +79,14 @@
         }
       ],
       "source": [
-        "%pip install landingai"
+        "%pip install landingai\n",
+        "\n",
+        "# NOTE: if you are running this notebook in Google Colab, you may see a warning message like this:\n",
+        "# \"WARNING: The following packages were previously imported in this runtime:\n",
+        "#  [PIL]\n",
+        "# You must restart the runtime in order to use newly installed versions.\"\n",
+        "#\n",
+        "# If so, you need to restart the kernel after installing the `landingai` package."
       ]
     },
     {
@@ -379,7 +394,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.10.11"
     },
     "vscode": {
       "interpreter": {

--- a/landingai/io.py
+++ b/landingai/io.py
@@ -48,10 +48,10 @@ def probe_video(video_file: str, samples_per_second: float) -> tuple[int, int, f
 
     Returns
     -------
-    A tuple of three values:
-    1. the total number of frames,
-    2. the number of frames to sample,
-    3. the video length in seconds.
+    A tuple of three values
+        1. the total number of frames,
+        2. the number of frames to sample,
+        3. the video length in seconds.
     """
     if not Path(video_file).exists():
         raise FileNotFoundError(f"Video file {video_file} does not exist.")

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -20,12 +20,14 @@ def class_counts(predictions: Sequence[Prediction]) -> dict[int, tuple[int, str]
     Returns
     -------
     A map with the predicted class/label index as the key, and a tuple of
-    (the number of occurrence, class/label name) as the value.
-    Example:
-        {
-            1: (10, "cat"),
-            2: (31, "dog"),
-        }
+        (the number of occurrence, class/label name) as the value.
+        ```
+        Example:
+            {
+                1: (10, "cat"),
+                2: (31, "dog"),
+            }
+        ```
     """
     counts: dict[int, list[int | str]] = defaultdict(lambda: [0, ""])
     for pred in predictions:
@@ -61,14 +63,15 @@ def class_pixel_coverage(
     Returns
     -------
     A map with the predicted class/label index as the key, and a tuple of
-    (the coverage, class/label name) as the value.
-
-    Example (coverage_type="absolute"):
-        {
-            0: (23512, "blue"),
-            1: (1230, "green"),
-            2: (0, "pink"),
-        }
+        (the coverage, class/label name) as the value.
+        ```
+        Example (coverage_type="absolute"):
+            {
+                0: (23512, "blue"),
+                1: (1230, "green"),
+                2: (0, "pink"),
+            }
+        ```
     """
     assert isinstance(
         predictions[0], SegmentationPrediction
@@ -99,16 +102,17 @@ def segmentation_class_pixel_coverage(
     Returns
     -------
     A map with the predicted class/label index as the key, and a tuple of
-    (the coverage percentage, class/label name) as the value.
-    NOTE: the sum of the coverage percentage over all classes is not guaranteed
-    to be 1.
-
-    Example (coverage_type="relative"):
-        {
-            0: (0.15, "blue"),
-            1: (0.31, "green"),
-            2: (0.07, "pink"),
-        }
+        (the coverage percentage, class/label name) as the value.
+        NOTE: the sum of the coverage percentage over all classes is not guaranteed
+        to be 1.
+        ```
+        Example (coverage_type="relative"):
+            {
+                0: (0.15, "blue"),
+                1: (0.31, "green"),
+                2: (0.07, "pink"),
+            }
+        ```
     """
     total_pixels: int = sum([math.prod(pred.mask_shape) for pred in predictions])
     pixel_counts: dict[int, list] = defaultdict(lambda: [0, ""])


### PR DESCRIPTION
1. Add more instructions to the farmland-coverage notebook
2. Add instructions to poker cards examples to remind users to restart the kernel  if running on Google colab (this is to avoid an runtime error caused by Pillow version mismatch)
3. Tweak the format of a few API docs so it can be shown properly