### PR TITLE
Support python 3.8+; Make CI runs against Window, MacOS, Linux

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ jobs:
   Test:
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.11]
+        python-version: [3.8, 3.10.11]
         os: [ ubuntu-22.04, windows-2022, macos-12 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -33,8 +33,6 @@ jobs:
       run: |
         # Install main dependencies first so we can see their size
         poetry install --all-extras
-        echo "Print installed dependencies by size:"
-        poetry run pip list | tail -n +3 | awk '{print $1}' | xargs poetry run pip show | grep -E 'Location:|Name:' | cut -d ' ' -f 2 | paste -d ' ' - - | awk '{print $2 "/" tolower($1)}' | xargs du -sh 2> /dev/null | sort -hr
     - name: Linting
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,12 +7,16 @@ on:
 
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10.11]
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.10.11
+        python-version: ${{ matrix.python-version }}
     - name: Install Python Poetry
       uses: abatilo/actions-poetry@v2.1.0
       with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![ci_status](https://github.com/landing-ai/landingai-python/actions/workflows/ci_cd.yml/badge.svg)
 ![pypi](https://badge.fury.io/py/landingai.svg)
 ![version](https://img.shields.io/pypi/pyversions/landingai)
 ![license](https://img.shields.io/github/license/landing-ai/landingai-python)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+![pypi](https://badge.fury.io/py/landingai.svg)
+![version](https://img.shields.io/pypi/pyversions/landingai)
+![license](https://img.shields.io/github/license/landing-ai/landingai-python)
+
+<br>
+
 <p align="center">
   <img width="100" height="100" src="https://github.com/landing-ai/landingai-python/raw/main/assets/avi-logo.png">
 </p>

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -1,7 +1,7 @@
 import math
 import re
 from functools import cached_property
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 from pydantic import BaseModel, BaseSettings
@@ -120,7 +120,7 @@ class SegmentationPrediction(Prediction):
         keep_untouched = (cached_property,)
 
 
-def decode_bitmap_rle(bitmap: str, encoding_map: Dict[str, int]) -> list[int]:
+def decode_bitmap_rle(bitmap: str, encoding_map: Dict[str, int]) -> List[int]:
     """
     Decode bitmap string to NumPy array.
 

--- a/landingai/io.py
+++ b/landingai/io.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import List, Tuple
 
 import cv2
 import requests
@@ -38,7 +39,7 @@ def read_file(url: str) -> bytes:
     return response.content
 
 
-def probe_video(video_file: str, samples_per_second: float) -> tuple[int, int, float]:
+def probe_video(video_file: str, samples_per_second: float) -> Tuple[int, int, float]:
     """Probe a video file to get some metadata before sampling images.
 
     Parameters
@@ -67,7 +68,7 @@ def probe_video(video_file: str, samples_per_second: float) -> tuple[int, int, f
 
 def sample_images_from_video(
     video_file: str, output_dir: Path, samples_per_second: float = 1
-) -> list[str]:
+) -> List[str]:
     """Sample images from a video file.
 
     Parameters

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -1,6 +1,6 @@
 import math
 from collections import defaultdict
-from typing import Sequence, cast
+from typing import Dict, List, Sequence, Tuple, cast
 
 from landingai.common import (
     ObjectDetectionPrediction,
@@ -9,12 +9,12 @@ from landingai.common import (
 )
 
 
-def class_map(predictions: Sequence[Prediction]) -> dict[int, str]:
+def class_map(predictions: Sequence[Prediction]) -> Dict[int, str]:
     """Return a map from the predicted class/label index to the class/label name."""
     return {pred.label_index: pred.label_name for pred in predictions}
 
 
-def class_counts(predictions: Sequence[Prediction]) -> dict[int, tuple[int, str]]:
+def class_counts(predictions: Sequence[Prediction]) -> Dict[int, Tuple[int, str]]:
     """Compute the distribution of the occurrences of each class.
 
     Returns
@@ -29,7 +29,7 @@ def class_counts(predictions: Sequence[Prediction]) -> dict[int, tuple[int, str]
             }
         ```
     """
-    counts: dict[int, list[int | str]] = defaultdict(lambda: [0, ""])
+    counts: Dict[int, List[int | str]] = defaultdict(lambda: [0, ""])
     for pred in predictions:
         counts[pred.label_index][0] = cast(int, counts[pred.label_index][0]) + 1
         counts[pred.label_index][1] = pred.label_name
@@ -39,7 +39,7 @@ def class_counts(predictions: Sequence[Prediction]) -> dict[int, tuple[int, str]
 def class_pixel_coverage(
     predictions: Sequence[Prediction],
     coverage_type: str = "relative",
-) -> dict[int, tuple[float, str]]:
+) -> Dict[int, Tuple[float, str]]:
     """Compute the pixel coverage of each class.
 
     Supported prediction types are:
@@ -76,21 +76,21 @@ def class_pixel_coverage(
     assert isinstance(
         predictions[0], SegmentationPrediction
     ), "Only support SegmentationPrediction for now."
-    predictions = cast(list[SegmentationPrediction], predictions)
+    predictions = cast(List[SegmentationPrediction], predictions)
     return segmentation_class_pixel_coverage(predictions, coverage_type)
 
 
 def od_class_pixel_coverage(
     predictions: Sequence[ObjectDetectionPrediction],
     coverage_type: str = "relative",
-) -> dict[int, tuple[float, str]]:
+) -> Dict[int, Tuple[float, str]]:
     raise NotImplementedError()
 
 
 def segmentation_class_pixel_coverage(
     predictions: Sequence[SegmentationPrediction],
     coverage_type: str = "relative",
-) -> dict[int, tuple[float, str]]:
+) -> Dict[int, Tuple[float, str]]:
     """Compute the pixel coverage of each class.
     The coverage is defined as the percentage of pixels that are predicted as the class
     over the sum total number of pixels of every mask.
@@ -115,11 +115,11 @@ def segmentation_class_pixel_coverage(
         ```
     """
     total_pixels: int = sum([math.prod(pred.mask_shape) for pred in predictions])
-    pixel_counts: dict[int, list] = defaultdict(lambda: [0, ""])
+    pixel_counts: Dict[int, List] = defaultdict(lambda: [0, ""])
     for pred in predictions:
         pixel_counts[pred.label_index][0] += pred.num_predicted_pixels
         pixel_counts[pred.label_index][1] = pred.label_name
-    coverages: dict[int, tuple[float, str]] = {}
+    coverages: Dict[int, Tuple[float, str]] = {}
     if coverage_type == "relative":
         total_pixels = sum([math.prod(pred.mask_shape) for pred in predictions])
     else:

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -1,6 +1,6 @@
 import math
 from collections import defaultdict
-from typing import Dict, List, Sequence, Tuple, cast
+from typing import Dict, List, Sequence, Tuple, Union, cast
 
 from landingai.common import (
     ObjectDetectionPrediction,
@@ -29,7 +29,7 @@ def class_counts(predictions: Sequence[Prediction]) -> Dict[int, Tuple[int, str]
             }
         ```
     """
-    counts: Dict[int, List[int | str]] = defaultdict(lambda: [0, ""])
+    counts: Dict[int, List[Union[int, str]]] = defaultdict(lambda: [0, ""])
     for pred in predictions:
         counts[pred.label_index][0] = cast(int, counts[pred.label_index][0]) + 1
         counts[pred.label_index][1] = pred.label_name

--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import PIL.Image
@@ -24,7 +24,6 @@ class Predictor:
     """A class that calls your inference endpoint on the LandingLens platform."""
 
     _url: str = "https://predict.app.landing.ai/inference/v1/predict"
-    # _url: str = "https://httpstat.us/503"  # Test URL
 
     def __init__(
         self,
@@ -94,7 +93,7 @@ class Predictor:
         )
         return session
 
-    def predict(self, image: np.ndarray | PIL.Image.Image) -> list[Prediction]:
+    def predict(self, image: np.ndarray | PIL.Image.Image) -> List[Prediction]:
         """Call the inference endpoint and return the prediction result.
 
         Parameters
@@ -135,7 +134,7 @@ def _configure_logger() -> None:
     requests_log.propagate = False
 
 
-def _extract_prediction(response: Dict[str, Any]) -> list[Prediction]:
+def _extract_prediction(response: Dict[str, Any]) -> List[Prediction]:
     response_type = response["backbonetype"]
     if response_type is None and response["type"] == "SegmentationPrediction":
         response_type = "SegmentationPredictionVP"  # Visual Prompting response
@@ -147,7 +146,7 @@ def _extract_prediction(response: Dict[str, Any]) -> list[Prediction]:
 
 def _extract_class_prediction(
     response: Dict[str, Any]
-) -> list[ClassificationPrediction]:
+) -> List[ClassificationPrediction]:
     """Extract Classification prediction result from response
 
     Parameters
@@ -185,7 +184,7 @@ def _extract_class_prediction(
     ]
 
 
-def _extract_od_prediction(response: Dict[str, Any]) -> list[ObjectDetectionPrediction]:
+def _extract_od_prediction(response: Dict[str, Any]) -> List[ObjectDetectionPrediction]:
     """Extract Object Detection prediction result from response
 
     Parameters
@@ -295,7 +294,7 @@ def _extract_od_prediction(response: Dict[str, Any]) -> list[ObjectDetectionPred
     ]
 
 
-def _extract_seg_prediction(response: Dict[str, Any]) -> list[SegmentationPrediction]:
+def _extract_seg_prediction(response: Dict[str, Any]) -> List[SegmentationPrediction]:
     """Extract Segmentation prediction result from response
 
     Parameters
@@ -323,7 +322,7 @@ def _extract_seg_prediction(response: Dict[str, Any]) -> list[SegmentationPredic
     ]
 
 
-def _extract_vp_prediction(response: Dict[str, Any]) -> list[SegmentationPrediction]:
+def _extract_vp_prediction(response: Dict[str, Any]) -> List[SegmentationPrediction]:
     """Extract Visual Prompting result from response
 
     Parameters

--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import PIL.Image
@@ -93,7 +93,7 @@ class Predictor:
         )
         return session
 
-    def predict(self, image: np.ndarray | PIL.Image.Image) -> List[Prediction]:
+    def predict(self, image: Union[np.ndarray, PIL.Image.Image]) -> List[Prediction]:
         """Call the inference endpoint and return the prediction result.
 
         Parameters

--- a/landingai/storage/snowflake.py
+++ b/landingai/storage/snowflake.py
@@ -60,7 +60,7 @@ def save_remote_file_to_local(
     remote_filename: str,
     stage_name: str,
     *,
-    local_output: Path | None = None,
+    local_output: Optional[Path] = None,
     credential: Optional[SnowflakeCredential] = None,
     connection_config: Optional[SnowflakeDBConfig] = None,
 ) -> Path:

--- a/landingai/vision_pipeline.py
+++ b/landingai/vision_pipeline.py
@@ -1,20 +1,20 @@
 """The vision pipeline is a layer that allows chaining image processing operations as a sequential pipeline. The main class passed throughout a pipeline is the `FrameSet` which typically contains a source image and derivative metadata and images.
 """
 
-from landingai.visualize import overlay_predictions
-from landingai.predict import Predictor
-from landingai.common import Prediction
+import logging
+import threading
+import time
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Union
 
+import cv2
 import numpy as np
 from PIL import Image
-import cv2
-
-from datetime import datetime
-import logging
-import time
-import threading
-from typing import Dict, Any, Callable, Union
 from pydantic import BaseModel, PrivateAttr
+
+from landingai.common import Prediction
+from landingai.predict import Predictor
+from landingai.visualize import overlay_predictions
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class Frame(BaseModel):
     other_images: Dict[str, Image.Image] = {}
     """Other derivative images associated with this frame (e.g. detection overlay)"""
 
-    predictions: list[Prediction] = []
+    predictions: List[Prediction] = []
     """List of predictions for the main image"""
 
     metadata: Dict[str, Any] = {}
@@ -54,7 +54,7 @@ class Frame(BaseModel):
 class FrameSet(BaseModel):
     """A FrameSet is a collection of frames (in order). Typically a FrameSet will include a single image but there are circumstances where other images will be extracted from the initial one. For example: we may want to identify vehicles on an initial image and then extract sub-images for each of the vehicles."""
 
-    frames: list[Frame] = []  # Start with empty frame set
+    frames: List[Frame] = []  # Start with empty frame set
 
     @classmethod
     def from_image(cls, file: str) -> "FrameSet":

--- a/landingai/visualize.py
+++ b/landingai/visualize.py
@@ -1,7 +1,7 @@
 """The landingai.visualize module contains functions to visualize the prediction results."""
 
 import logging
-from typing import Any, Callable, Optional, Type, cast
+from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
 
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
@@ -17,9 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def overlay_predictions(
-    predictions: list[Prediction],
+    predictions: List[Prediction],
     image: np.ndarray | Image.Image,
-    options: dict[str, Any] | None = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Overlay the prediction results on the input image and return the image with the overlay."""
     if len(predictions) == 0:
@@ -29,15 +29,15 @@ def overlay_predictions(
     assert len(types) == 1, f"Expecting only one type of prediction, got {types}"
     pred_type = types.pop()
     overlay_func: Callable[
-        [list[Prediction], np.ndarray | Image.Image, Optional[dict]], Image.Image
+        [List[Prediction], Union[np.ndarray, Image.Image], Optional[Dict]], Image.Image
     ] = _OVERLAY_FUNC_MAP[pred_type]
     return overlay_func(predictions, image, options)
 
 
 def overlay_bboxes(
-    predictions: list[ObjectDetectionPrediction],
+    predictions: List[ObjectDetectionPrediction],
     image: np.ndarray | Image.Image,
-    options: dict[str, Any] | None = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Draw bounding boxes on the input image and return the image with bounding boxes drawn.
     The bounding boxes are drawn using the bbox-visualizer package.
@@ -97,9 +97,9 @@ def overlay_bboxes(
 
 
 def overlay_colored_masks(
-    predictions: list[SegmentationPrediction],
+    predictions: List[SegmentationPrediction],
     image: np.ndarray | Image.Image,
-    options: dict[str, Any] | None = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Draw colored masks on the input image and return the image with colored masks drawn.
 
@@ -135,9 +135,9 @@ def overlay_colored_masks(
 
 
 def overlay_predicted_class(
-    predictions: list[ClassificationPrediction],
+    predictions: List[ClassificationPrediction],
     image: np.ndarray | Image.Image,
-    options: dict[str, Any] | None = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Draw the predicted class on the input image and return the image with the predicted class drawn.
 
@@ -183,9 +183,9 @@ def _get_pil_font(font_size: int = 18) -> ImageFont.FreeTypeFont:
     return ImageFont.truetype(file, font_size)
 
 
-_OVERLAY_FUNC_MAP: dict[
+_OVERLAY_FUNC_MAP: Dict[
     Type[Prediction],
-    Callable[[list[Any], np.ndarray | Image.Image, Optional[dict]], Image.Image],
+    Callable[[List[Any], Union[np.ndarray, Image.Image], Optional[Dict]], Image.Image],
 ] = {
     ObjectDetectionPrediction: overlay_bboxes,
     SegmentationPrediction: overlay_colored_masks,

--- a/landingai/visualize.py
+++ b/landingai/visualize.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def overlay_predictions(
     predictions: List[Prediction],
-    image: np.ndarray | Image.Image,
+    image: Union[np.ndarray, Image.Image],
     options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Overlay the prediction results on the input image and return the image with the overlay."""
@@ -36,7 +36,7 @@ def overlay_predictions(
 
 def overlay_bboxes(
     predictions: List[ObjectDetectionPrediction],
-    image: np.ndarray | Image.Image,
+    image: Union[np.ndarray, Image.Image],
     options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Draw bounding boxes on the input image and return the image with bounding boxes drawn.
@@ -98,7 +98,7 @@ def overlay_bboxes(
 
 def overlay_colored_masks(
     predictions: List[SegmentationPrediction],
-    image: np.ndarray | Image.Image,
+    image: Union[np.ndarray, Image.Image],
     options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Draw colored masks on the input image and return the image with colored masks drawn.
@@ -136,7 +136,7 @@ def overlay_colored_masks(
 
 def overlay_predicted_class(
     predictions: List[ClassificationPrediction],
-    image: np.ndarray | Image.Image,
+    image: Union[np.ndarray, Image.Image],
     options: Optional[Dict[str, Any]] = None,
 ) -> Image.Image:
     """Draw the predicted class on the input image and return the image with the predicted class drawn.

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 import numpy as np
 from PIL import Image
@@ -131,7 +131,7 @@ def test_class_predict():
     img_with_masks.save("tests/output/test_class.jpg")
 
 
-def _assert_seg_mask(pred: SegmentationPrediction, expected: dict[str, Any]):
+def _assert_seg_mask(pred: SegmentationPrediction, expected: Dict[str, Any]):
     assert pred.label_name == expected["label_name"]
     assert pred.label_index == expected["label_index"]
     assert pred.score == expected["score"]


### PR DESCRIPTION
# Main changes

1. Remove syntax that is only available in 3.10.
2. Configure CI to run against Window, MacOS, Linux, and Python 3.8, 3.10.
3. Add a few badges to README (see below screenshot as an example)

No functional changes are introduced in this PR.

<img width="478" alt="image" src="https://github.com/landing-ai/landingai-python/assets/92344512/73d04262-56b4-4550-9606-fca4d4693d66">
