### PR TITLE
Fix the image color layout in the poker notebook example

### DIFF
--- a/examples/webcam-collab-notebook/webcam-collab-notebook.ipynb
+++ b/examples/webcam-collab-notebook/webcam-collab-notebook.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "WRNDUR9dZdKk"
@@ -89,6 +90,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "UtVwPbd_6xPL"
@@ -174,6 +176,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "oXEb0iA6ZdKo"
@@ -228,10 +231,13 @@
     "  # grant the page permission to access it.\n",
     "  print(str(err))\n",
     "\n",
-    "frame = cv2.imread(filename)"
+    "frame = cv2.imread(filename)\n",
+    "# Convert color space to RGB\n",
+    "frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "IKwEwD3DZdKq"
@@ -277,6 +283,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "Fc5RguovZdKs"
@@ -309,16 +316,15 @@
     }
    ],
    "source": [
-    "# Convert color space to RGB\n",
-    "frame2 = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)\n",
     "# Draw raw results on the original image\n",
-    "frame3 = overlay_predictions(results, image=frame2)\n",
+    "frame_with_preds = overlay_predictions(results, image=frame)\n",
     "\n",
-    "plt.imshow(frame3)\n",
+    "plt.imshow(frame_with_preds)\n",
     "plt.show()\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "P7qpMhPXZdKu"


### PR DESCRIPTION
In the poker notebook,  the image was read as BGR instead of RGB. 
This PR fixes the issue.