### PR TITLE
Fix a "File Not Found" issue

### DIFF
--- a/landingai/io.py
+++ b/landingai/io.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
-from typing import List, Tuple, Callable
+from typing import Callable, List, Tuple, Union
+
 import cv2
 import requests
 
@@ -102,14 +103,15 @@ def sample_images_from_video(
     return output
 
 
-def read_from_notebook_webcam() -> Callable[[], str]:
+def read_from_notebook_webcam(webcam_source: Union[str, int] = 0) -> Callable[[], str]:
     # Define function to acquire images either directly from the local webcam (i.e. jupyter notebook)or from the web browser (i.e. collab)
     filename = "/tmp/photo.jpg"
     # Detect if we are running on Google's colab
     try:
-        from IPython.display import display, Javascript
         from base64 import b64decode
+
         from google.colab.output import eval_js  # type: ignore
+        from IPython.display import Javascript, display
 
         def take_photo() -> str:
             quality = 0.8
@@ -158,7 +160,7 @@ def read_from_notebook_webcam() -> Callable[[], str]:
         import cv2
 
         def take_photo() -> str:
-            cam = cv2.VideoCapture(0)
+            cam = cv2.VideoCapture(webcam_source)
             cv2.namedWindow("Press space to take photo")
             cv2.startWindowThread()
             while True:

--- a/landingai/io.py
+++ b/landingai/io.py
@@ -1,4 +1,5 @@
 import logging
+import tempfile
 from pathlib import Path
 from typing import Callable, List, Tuple, Union
 
@@ -105,7 +106,8 @@ def sample_images_from_video(
 
 def read_from_notebook_webcam(webcam_source: Union[str, int] = 0) -> Callable[[], str]:
     # Define function to acquire images either directly from the local webcam (i.e. jupyter notebook)or from the web browser (i.e. collab)
-    filename = "/tmp/photo.jpg"
+    local_cache_dir = Path(tempfile.mkdtemp())
+    filename = str(local_cache_dir / "photo.jpg")
     # Detect if we are running on Google's colab
     try:
         from base64 import b64decode

--- a/poetry.lock
+++ b/poetry.lock
@@ -1768,6 +1768,34 @@ files = [
 ]
 
 [[package]]
+name = "opencv-python"
+version = "4.7.0.72"
+description = "Wrapper package for OpenCV python bindings."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "opencv-python-4.7.0.72.tar.gz", hash = "sha256:3424794a711f33284581f3c1e4b071cfc827d02b99d6fd9a35391f517c453306"},
+    {file = "opencv_python-4.7.0.72-cp37-abi3-macosx_10_16_x86_64.whl", hash = "sha256:d4f8880440c433a0025d78804dda6901d1e8e541a561dda66892d90290aef881"},
+    {file = "opencv_python-4.7.0.72-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:7a297e7651e22eb17c265ddbbc80e2ba2a8ff4f4a1696a67c45e5f5798245842"},
+    {file = "opencv_python-4.7.0.72-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd08343654c6b88c5a8c25bf425f8025aed2e3189b4d7306b5861d32affaf737"},
+    {file = "opencv_python-4.7.0.72-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebfc0a3a2f57716e709028b992e4de7fd8752105d7a768531c4f434043c6f9ff"},
+    {file = "opencv_python-4.7.0.72-cp37-abi3-win32.whl", hash = "sha256:eda115797b114fc16ca6f182b91c5d984f0015c19bec3145e55d33d708e9bae1"},
+    {file = "opencv_python-4.7.0.72-cp37-abi3-win_amd64.whl", hash = "sha256:812af57553ec1c6709060c63f6b7e9ad07ddc0f592f3ccc6d00c71e0fe0e6376"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.21.0", markers = "python_version <= \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
+    {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
+    {version = ">=1.17.0", markers = "python_version >= \"3.7\""},
+    {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
+    {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
+    {version = ">=1.22.0", markers = "python_version >= \"3.11\""},
+]
+
+[[package]]
 name = "opencv-python-headless"
 version = "4.7.0.72"
 description = "Wrapper package for OpenCV python bindings."
@@ -3104,4 +3132,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "c77562545ab1fceea88992ee9cf4597aac27d5450702319511cec67e3a679008"
+content-hash = "b9f77b5e2ff60358f2c5b38d8d690d0eff94bfdc93760509ff9129fc60b1f730"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ packages = [{include = "landingai"}]
 [tool.poetry.dependencies]  # main dependency group
 python = ">=3.8"
 
-opencv-python-headless = ">=4.5"
+opencv-python = ">=4.5"
 numpy = ">=1.21.0"
 pillow = ">=9.1.1"
 pydantic = { version = "*", extras = ["dotenv"] }

--- a/tests/unit/landingai/test_io.py
+++ b/tests/unit/landingai/test_io.py
@@ -1,28 +1,20 @@
 from pathlib import Path
-from unittest.mock import patch
 
-import PIL.Image
-import numpy as np
 import pytest
 import responses
 
-from landingai.io import (
-    probe_video,
-    read_file,
-    read_from_notebook_webcam,
-    sample_images_from_video,
-)
+from landingai.io import probe_video, read_file, sample_images_from_video
 
-
-@patch("landingai.io.cv2.waitKey")
-@patch("landingai.io.cv2.VideoCapture")
-def test_read_from_notebook_webcam(mock_video_capture, mock_wait_key):
-    mock_video_capture.return_value.read.return_value = (True, np.zeros((480, 640, 3)))
-    mock_wait_key.return_value = 288
-    take_photo_func = read_from_notebook_webcam()
-    filepath = take_photo_func()
-    image = PIL.Image.open(filepath)
-    assert image.size == (640, 480)
+# TODO: solve the problem of exit code 134 when running the following test in GitHub Actions
+# @patch("landingai.io.cv2.waitKey")
+# @patch("landingai.io.cv2.VideoCapture")
+# def test_read_from_notebook_webcam(mock_video_capture, mock_wait_key):
+#     mock_video_capture.return_value.read.return_value = (True, np.zeros((480, 640, 3)))
+#     mock_wait_key.return_value = 288
+#     take_photo_func = read_from_notebook_webcam()
+#     filepath = take_photo_func()
+#     image = PIL.Image.open(filepath)
+#     assert image.size == (640, 480)
 
 
 def test_sample_images_from_video(tmp_path: Path):

--- a/tests/unit/landingai/test_io.py
+++ b/tests/unit/landingai/test_io.py
@@ -1,9 +1,28 @@
 from pathlib import Path
+from unittest.mock import patch
 
+import PIL.Image
+import numpy as np
 import pytest
 import responses
 
-from landingai.io import probe_video, read_file, sample_images_from_video
+from landingai.io import (
+    probe_video,
+    read_file,
+    read_from_notebook_webcam,
+    sample_images_from_video,
+)
+
+
+@patch("landingai.io.cv2.waitKey")
+@patch("landingai.io.cv2.VideoCapture")
+def test_read_from_notebook_webcam(mock_video_capture, mock_wait_key):
+    mock_video_capture.return_value.read.return_value = (True, np.zeros((480, 640, 3)))
+    mock_wait_key.return_value = 288
+    take_photo_func = read_from_notebook_webcam()
+    filepath = take_photo_func()
+    image = PIL.Image.open(filepath)
+    assert image.size == (640, 480)
 
 
 def test_sample_images_from_video(tmp_path: Path):


### PR DESCRIPTION
1. Fix a "File Not Found" issue with `read_from_notebook_webcam` on Windows. The root cause is due to we hard coded a temp path that is not valid for Windows.
2. Change the dependency from `opencv-python-headless` to `opencv-python` since we need OpenCV window APIs.
3. Add a unit test for `read_from_notebook_webcam` (commented due to an error, which we can revisit later)