### PR TITLE
[skip release][Breaking]Support v2 API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install landingai
 This library needs to communicate with the LandingLens platform to perform certain functions. (For example, the `Predictor` API calls the HTTP endpoint of your deployed model). To enable communication with LandingLens, you will need the following information:
 
 1. The **Endpoint ID** of your deployed model in LandingLens. You can find this on the Deploy page in LandingLens.
-2. The **API Key** and **API Secret** for the LandingLens organization that has the model you want to deploy. To learn how to generate these credentials, go [here](https://support.landing.ai/docs/api-key-and-api-secret).
+2. The **API Key** for the LandingLens organization that has the model you want to deploy. To learn how to generate these credentials, go [here](https://support.landing.ai/docs/api-key-and-api-secret).
 
 ### Run Inference
 Run inference using the endpoint you created in LandingLens:
@@ -54,11 +54,10 @@ from landingai.predict import Predictor
 # Enter your API Key and Secret
 endpoint_id = "FILL_YOUR_INFERENCE_ENDPOINT_ID"
 api_key = "FILL_YOUR_API_KEY"
-api_secret = "FILL_YOUR_API_SECRET"
 # Load your image
 image = np.asarray(Image.open("image.png"))
 # Run inference
-predictor = Predictor(endpoint_id, api_key, api_secret)
+predictor = Predictor(endpoint_id, api_key=api_key)
 predictions = predictor.predict(image)
 ```
 

--- a/docs/user_guide/2_credentials.md
+++ b/docs/user_guide/2_credentials.md
@@ -1,12 +1,27 @@
 ## Manage API Credentials
 
-Here are the three ways to configure your API Key and API Secret, ordered by the priority in which they are loaded:
+If you send images to an endpoint through API (Cloud Deployment), you must add your API Key to the API call. You can generate the API Key in LandingLens. This API key is also known as API key v2. See [here](https://support.landing.ai/docs/api-key-and-api-secret) for more information.
 
-1. Pass them as function parameters. See `landingai.predict.Predictor`.
-2. Set them as environment variables. For example: `export LANDINGAI_API_KEY=...`, `export LANDINGAI_API_SECRET=...`.
-3. Store them in an `.env` file under your project root directory. For example, here is a set of credentials in an `.env` file:
+Once you have generated the API key, here are three ways to configure your API Key, ordered by the priority in which they are loaded:
+
+1. Pass it as function parameters. See `landingai.predict.Predictor`.
+2. Set it as environment variables. For example: `export LANDINGAI_API_KEY=...`.
+3. Store it in an `.env` file under your project root directory. For example, here is a set of credentials in an `.env` file:
 
 ```
-   LANDINGAI_API_KEY=v7b0hdyfj6271xy2o9lmiwkkcb12345
-   LANDINGAI_API_SECRET=ao6yjcju7q1e6u0udgwrgknhrx6m4n1o48z81jy6huc059gne047l4fq312345
+   LANDINGAI_API_KEY=land_sk_v7b0hdyfj6271xy2o9lmiwkkcb12345
 ```
+
+### Legacy API key and secret
+
+In the past, LandingLens supports generating a key and secret pair, which is known as API key v1. This approach is not recommended anymore.
+But if you have a v1 key and secret pair, you can still use the Python SDK via either setting environment variables or an `.env` file, i.e. the #2 and #3 methods above.
+
+### FAQ
+
+#### What's the difference between the v1 API key and v2 API key
+
+Here are a few differences:
+1. The v2 API key always starts with a prefix "land_sk_" whereas the v1 API key doesn't.
+2. The v1 API key always comes with a secret string, and the SDK requires both whereas the v2 API key only has a single string.
+3. Users can only generate v2 API keys after July 2023.

--- a/docs/user_guide/5_data_management.md
+++ b/docs/user_guide/5_data_management.md
@@ -3,9 +3,9 @@
 The `landingai` library provides a set of APIs to manage dataset medias (e.g. images) and their metadata.
 This section explains how to use the associated Python APIs to:
 
--   Upload new (single) Media with metadata
--   Upload ALL medias from Folder with metadata
--   Set Metadata for existing Medias
+-   Upload new (single) media with metadata
+-   Upload all medias from folder with metadata
+-   Set metadata for existing medias
 
 
 ### Introduction to Metadata

--- a/examples/apps/image-folder-support/app.py
+++ b/examples/apps/image-folder-support/app.py
@@ -143,10 +143,7 @@ def convert_df(df):
 
 
 def is_landing_credentials_set():
-    return (
-        st.session_state.get("endpoint_id")
-        and st.session_state.get("api_key")
-    )
+    return st.session_state.get("endpoint_id") and st.session_state.get("api_key")
 
 
 def reset_states():

--- a/examples/apps/image-folder-support/app.py
+++ b/examples/apps/image-folder-support/app.py
@@ -109,8 +109,7 @@ class ImageFolderResult:
 def bulk_inference(image_paths: list[str], image_folder_path: str) -> ImageFolderResult:
     endpoint_id = st.session_state["endpoint_id"]
     api_key = st.session_state["api_key"]
-    api_secret = st.session_state["api_secret"]
-    predictor = Predictor(endpoint_id, api_key=api_key, api_secret=api_secret)
+    predictor = Predictor(endpoint_id, api_key=api_key)
     images = [np.asarray(PIL.Image.open(p)) for p in image_paths]
     local_cache_dir = Path(tempfile.mkdtemp())
     pbar = st.progress(0, text="Running inferences...")
@@ -147,7 +146,6 @@ def is_landing_credentials_set():
     return (
         st.session_state.get("endpoint_id")
         and st.session_state.get("api_key")
-        and st.session_state.get("api_secret")
     )
 
 

--- a/examples/apps/object-tracking/main.py
+++ b/examples/apps/object-tracking/main.py
@@ -10,21 +10,15 @@ st.write("Please enter your LandingLens API credentials and CloudInference Endpo
 api_key = st.text_input(
     "LandingLens API Key", value=st.session_state.get("api_key", "")
 )
-api_secret = st.text_input(
-    "LandingLens API Secret",
-    type="password",
-    value=st.session_state.get("api_secret", ""),
-)
 endpoint_id = st.text_input(
     "CloudInference Endpoint ID",
     value=st.session_state.get("endpoint_id", ""),
 )
 
 
-def save(api_key, api_secret, endpoint_id):
+def save(api_key, endpoint_id):
     st.session_state["api_key"] = api_key
-    st.session_state["api_secret"] = api_secret
     st.session_state["endpoint_id"] = endpoint_id
 
 
-st.button("Save", on_click=save(api_key, api_secret, endpoint_id))
+st.button("Save", on_click=save(api_key, endpoint_id))

--- a/examples/apps/object-tracking/pages/run_inference.py
+++ b/examples/apps/object-tracking/pages/run_inference.py
@@ -22,8 +22,7 @@ def get_latest_traffic():
     frames = get_frames("vid.ts")
     predictor = Predictor(
         st.session_state["endpoint_id"],
-        st.session_state["api_key"],
-        st.session_state["api_secret"],
+        api_key=st.session_state["api_key"],
     )
     bboxes = get_preds(frames, predictor)
     tracks, all_idx_to_track = track_iou(bboxes)

--- a/examples/apps/ocr/app.py
+++ b/examples/apps/ocr/app.py
@@ -103,7 +103,6 @@ def main():
             predictor = OcrPredictor(
                 threshold=float(threshold),
                 api_key=key,
-                api_secret="",
             )
             begin = time.perf_counter()
             logging.info(

--- a/examples/capture-service/README.md
+++ b/examples/capture-service/README.md
@@ -25,7 +25,7 @@ The program captures frames from the video feed every few seconds, and then runs
 1. Set up a camera that exposes an RTSP URL to your network (your local intranet). If you're not sure if the RTSP URL is working, learn how to test it in this [article](https://support.ipconfigure.com/hc/en-us/articles/115005588503-Using-VLC-to-test-camera-stream).
 2. Train a model in LandingLens, and deploy it to an endpoint via [Cloud Deployment](https://support.landing.ai/landinglens/docs/cloud-deployment).
 3. Get the `endpoint id`, `api key` and `api secret` from LandingLens.
-4. Open the file `examples/capture-service/run.py`, and update the following with your information: `api_key`, `api_secret`, `endpoint_id` and `stream_url`. 
+4. Open the file `examples/capture-service/run.py`, and update the following with your information: `api_key`, `endpoint_id` and `stream_url`.
 
 
 ## Collect Images to Train Your Model

--- a/examples/capture-service/run.py
+++ b/examples/capture-service/run.py
@@ -17,8 +17,7 @@ _CAPTURE_INTERVAL = (
 )
 
 # Public Cloud & Sky detection segmentation model
-api_key = "bu8y8czyonaip6ceov75nfnlpnr9blh"
-api_secret = "mdebq6hxq19fg86k3p53rwcxh16h2qudcfonl6sjrde334y2vxz4qj4wnefh05"
+api_key = "land_sk_aMemWbpd41yXnQ0tXvZMh59ISgRuKNRKjJEIUHnkiH32NBJAwf"
 endpoint_id = "432d58f6-6cd4-4108-a01c-2f023503d838"
 
 #
@@ -39,7 +38,7 @@ stream_url = (
 
 if __name__ == "__main__":
     # stream(capture_frame=False, inference_mode=True, detect_change=True)
-    cloud_sky_model = Predictor(endpoint_id, api_key, api_secret)
+    cloud_sky_model = Predictor(endpoint_id, api_key=api_key)
     Camera = NetworkedCamera(
         stream_url, motion_detection_threshold=1, capture_interval=_CAPTURE_INTERVAL
     )

--- a/examples/post-processings/farmland-coverage/farmland-coverage.ipynb
+++ b/examples/post-processings/farmland-coverage/farmland-coverage.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -16,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -91,6 +93,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -98,7 +101,7 @@
     "\n",
     "Before performing the coverage analsis, we have already trained a Visual Prompting model in LandingLens, and deployed it to a web endpoint via [Cloud Deployment](https://support.landing.ai/landinglens/docs/cloud-deployment).\n",
     "\n",
-    "The following cell includes the credentials needed to access the model and its endpoint: endpoint_id, api_key, and api_secret."
+    "The following cell defines the api_key needed to access the model and its endpoint with endpoint_id."
    ]
   },
   {
@@ -108,12 +111,12 @@
    "outputs": [],
    "source": [
     "#@title Set the following variables as needed for your setup\n",
-    "api_key = \"v7b0hdyfj6271xy2o9lmiwkkcbdpvt1\"\n",
-    "api_secret = \"ao6yjcju7q1e6u0udgwrgknhrx6m4n1o48z81jy6huc059gne047l4fq3u1cgq\"\n",
+    "api_key = \"land_sk_aMemWbpd41yXnQ0tXvZMh59ISgRuKNRKjJEIUHnkiH32NBJAwf\"\n",
     "endpoint_id = \"63035608-9d24-4342-8042-e4b08e084fde\""
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -139,6 +142,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -175,6 +179,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -195,13 +200,14 @@
    "source": [
     "from landingai.predict import Predictor\n",
     "\n",
-    "predictor = Predictor(endpoint_id, api_key, api_secret)\n",
+    "predictor = Predictor(endpoint_id, api_key=api_key)\n",
     "predictions = []\n",
     "for img in images:\n",
     "        predictions.extend(predictor.predict(img))"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -247,6 +253,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -290,6 +297,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/rtsp-capture-notebook/rtsp-capture.ipynb
+++ b/examples/rtsp-capture-notebook/rtsp-capture.ipynb
@@ -17,8 +17,7 @@
    "outputs": [],
    "source": [
     "#@title Set the following variables as needed for your setup\n",
-    "api_key         = \"bu8y8czyonaip6ceov75nfnlpnr9blh\"  #@param {type:\"string\"}\n",
-    "api_secret      = \"mdebq6hxq19fg86k3p53rwcxh16h2qudcfonl6sjrde334y2vxz4qj4wnefh05\"  #@param {type:\"string\"}\n",
+    "api_key         = \"land_sk_aMemWbpd41yXnQ0tXvZMh59ISgRuKNRKjJEIUHnkiH32NBJAwf\"  #@param {type:\"string\"}\n",
     "model_endpoint  =  \"881e04f4-1a16-4728-b19c-a6900d0b8d98\" #@param {type:\"string\"}\n",
     "# In order to find the URL for your camera, this is a good start https://www.ispyconnect.com/cameras\n",
     "# camera_url      =  \"rtsp://172.25.101.151/ch0_0.h264\" #@param {type:\"string\"}\n",
@@ -159,7 +158,7 @@
     "from landingai.predict import Predictor\n",
     "from landingai.visualize import overlay_predictions\n",
     "        \n",
-    "predictor = Predictor(model_endpoint, api_key, api_secret)\n",
+    "predictor = Predictor(model_endpoint, api_key=api_key)\n",
     "\n",
     "# Run prediction and show raw results\n",
     "results = predictor.predict(frame)\n",

--- a/examples/webcam-collab-notebook/webcam-collab-notebook.ipynb
+++ b/examples/webcam-collab-notebook/webcam-collab-notebook.ipynb
@@ -118,8 +118,7 @@
    "source": [
     "#@title Set the following variables as needed for your setup\n",
     "# These keys correspond to a public LandingLens model\n",
-    "api_key         = \"bu8y8czyonaip6ceov75nfnlpnr9blh\"  #@param {type:\"string\"}\n",
-    "api_secret      = \"mdebq6hxq19fg86k3p53rwcxh16h2qudcfonl6sjrde334y2vxz4qj4wnefh05\"  #@param {type:\"string\"}\n",
+    "api_key         = \"land_sk_aMemWbpd41yXnQ0tXvZMh59ISgRuKNRKjJEIUHnkiH32NBJAwf\"  #@param {type:\"string\"}\n",
     "model_endpoint  =  \"0b3ad59c-80ca-481b-977f-f2470cbe83e3\" #@param {type:\"string\"}\n"
    ]
   },
@@ -158,7 +157,7 @@
     "from landingai.predict import Predictor\n",
     "from landingai.visualize import overlay_predictions\n",
     "        \n",
-    "predictor = Predictor(model_endpoint, api_key, api_secret)\n",
+    "predictor = Predictor(model_endpoint, api_key=api_key)\n",
     "\n",
     "# Run prediction and show raw results\n",
     "results = predictor.predict(frame)\n",

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -5,11 +5,15 @@ from typing import Dict, List, Tuple
 
 import cv2
 import numpy as np
-from pydantic import BaseModel, BaseSettings
+from pydantic import BaseModel, BaseSettings, validator
+
+from landingai.exceptions import InvalidApiKeyError
 
 
 class APICredential(BaseSettings):
     """The API credentials of an organization in LandingLens.
+    NOTE: This is a legacy way to authenticate with the LandingLens API. Consider using the `APIKey` class instead.
+
     It supports loading from environment variables or .env files.
 
     The supported name of the environment variables are (case-insensitive):
@@ -21,6 +25,38 @@ class APICredential(BaseSettings):
 
     api_key: str
     api_secret: str
+
+    class Config:
+        env_file = ".env"
+        env_prefix = "landingai_"
+        case_sensitive = False
+
+
+class APIKey(BaseSettings):
+    """The API key of an organization in LandingLens.
+    It's also known as the "API Key v2" in LandingLens.
+    The difference between this v2 key and the legacy API key is that the v2 key only requires a single API key string.
+    The new v2 key string always starts with "land_sk_" prefix.
+    NOTE: This is the recommended way to authenticate with the LandingLens API.
+
+    It supports loading from environment variables or .env files.
+
+    The supported name of the environment variables are (case-insensitive):
+    - LANDINGAI_API_KEY
+
+    Environment variables will always take priority over values loaded from a dotenv file.
+    """
+
+    api_key: str
+
+    @validator("api_key")
+    def is_api_key_valid(cls, key: str) -> str:
+        """Check if the API key is a v2 key."""
+        if not key.startswith("land_sk_"):
+            raise InvalidApiKeyError(
+                f"API key (v2) must start with 'land_sk_' prefix, but it's {key}."
+            )
+        return key
 
     class Config:
         env_file = ".env"

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -16,7 +16,7 @@ from landingai.exceptions import InvalidApiKeyError
     category=None,
 )
 class APICredential(BaseSettings):
-    """The API credentials of an organization in LandingLens.
+    """The API credentials of an user in a particular organization in LandingLens.
     NOTE: This is a legacy way to authenticate with the LandingLens API. Consider using the `APIKey` class instead.
 
     It supports loading from environment variables or .env files.
@@ -38,7 +38,7 @@ class APICredential(BaseSettings):
 
 
 class APIKey(BaseSettings):
-    """The API key of an organization in LandingLens.
+    """The API key of an user in a particular organization in LandingLens.
     It's also known as the "API Key v2" in LandingLens.
     The difference between this v2 key and the legacy API key is that the v2 key only requires a single API key string.
     The new v2 key string always starts with "land_sk_" prefix.

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -58,7 +58,7 @@ class APIKey(BaseSettings):
         """Check if the API key is a v2 key."""
         if not key.startswith("land_sk_"):
             raise InvalidApiKeyError(
-                f"API key (v2) must start with 'land_sk_' prefix, but it's {key}."
+                f"API key (v2) must start with 'land_sk_' prefix, but it's {key}. See https://support.landing.ai/docs/api-key for more information."
             )
         return key
 

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -40,8 +40,7 @@ class APICredential(BaseSettings):
 class APIKey(BaseSettings):
     """The API key of an user in a particular organization in LandingLens.
     It's also known as the "API Key v2" in LandingLens.
-    The difference between this v2 key and the legacy API key is that the v2 key only requires a single API key string.
-    The new v2 key string always starts with "land_sk_" prefix.
+    The difference between this v2 key and the legacy API key is that the v2 key is a single string, and the string always starts with "land_sk_" prefix.
     NOTE: This is the recommended way to authenticate with the LandingLens API.
 
     It supports loading from environment variables or .env files.

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -2,6 +2,7 @@ import math
 import re
 from functools import cached_property
 from typing import Dict, List, Tuple
+from typing_extensions import deprecated
 
 import cv2
 import numpy as np
@@ -10,6 +11,10 @@ from pydantic import BaseModel, BaseSettings, validator
 from landingai.exceptions import InvalidApiKeyError
 
 
+@deprecated(
+    "Use `APIKey` instead, this class is kept for users who have legacy API key.",
+    category=None,
+)
 class APICredential(BaseSettings):
     """The API credentials of an organization in LandingLens.
     NOTE: This is a legacy way to authenticate with the LandingLens API. Consider using the `APIKey` class instead.

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -89,12 +89,28 @@ class Media:
         nothing_to_label: bool
             Set the media's label as OK, valid for object detection and segmetation project
         metadata_dict: dict
-            Pass in the metadata, need to be created before media uploading
+            A dictionary of metadata to be updated or inserted.
+            The key of the metadata needs to be created/registered (for the first time) before media uploading.
         validate_extensions: bool
             Defaults to True. Files other than jpg/jpeg/png/bmp will be skipped.
             If set to False, will try to upload all files. Behavior of platform
              for unexpected extensions may not be correct - for example, most likely file
              will be uploaded to s3, but won't show in data browser.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The result from the upload().
+            ```
+            # Example output
+            {
+                "num_uploaded": 10,
+                "skipped_count": 0,
+                "error_count": 0,
+                "medias": [...],
+                "files_with_errors": {},
+            }
+            ```
         """
         if isinstance(source, Path):
             source = str(source)

--- a/landingai/data_management/metadata.py
+++ b/landingai/data_management/metadata.py
@@ -22,6 +22,29 @@ class Metadata:
         media_ids: Union[int, List[int]],
         **input_metadata: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
+        """Update or insert a dictionary of metadata for a set of medias.
+
+        Parameters
+        ----------
+        media_ids
+            Media ids to update.
+        input_metadata
+            A dictionary of metadata to be updated or inserted.
+            The key of the metadata needs to be created/registered (for the first time) before media uploading.
+
+        Returns
+        ----------
+        Dict[str, Any]
+            The result from the update().
+            ```
+            # Example output
+            {
+                "project_id": 12345,
+                "metadata": [...],
+                "media_ids": [123, 124]],
+            }
+            ```
+        """
         project_id = self._client._project_id
         if (
             not media_ids

--- a/landingai/exceptions.py
+++ b/landingai/exceptions.py
@@ -10,6 +10,18 @@ from requests.structures import CaseInsensitiveDict
 _LOGGER = logging.getLogger(__name__)
 
 
+class InvalidApiKeyError(Exception):
+    """Exception raised when the an invalid API key is provided. This error could be raised from any SDK code, not limited to a HTTP client."""
+
+    def __init__(self, message: str):
+        self.message = f"""{message}
+For more information, see https://landing-ai.github.io/landingai-python/landingai.html#manage-api-credentials"""
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class UnauthorizedError(Exception):
     """Exception raised when the user is not authorized to access the resource. Status code: 401."""
 

--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -135,7 +135,6 @@ class OcrPredictor(Predictor):
         self,
         threshold: float = 0.5,
         *,
-        *,
         api_key: Optional[str] = None,
     ) -> None:
         """OCR Predictor constructor

--- a/landingai/utils.py
+++ b/landingai/utils.py
@@ -1,9 +1,13 @@
 """Module for common utility functions."""
 import io
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
-import PIL
+import PIL.Image
+from pydantic import ValidationError
+
+from landingai.common import APICredential, APIKey
+from landingai.exceptions import InvalidApiKeyError
 
 
 def serialize_image(image: Union[np.ndarray, PIL.Image.Image]) -> bytes:
@@ -18,3 +22,24 @@ def serialize_image(image: Union[np.ndarray, PIL.Image.Image]) -> bytes:
     buffer_bytes = img_buffer.getvalue()
     img_buffer.close()
     return buffer_bytes
+
+
+def load_api_credential(api_key: Optional[str] = None) -> Union[APIKey, APICredential]:
+    """Load API credential from different sources.
+    The API credential can be provided as arguments or loaded from the environment variables or .env file.
+    The priority is: arguments > environment variables > .env file.
+    The output is an APIKey (v2 key) or APICredential (v1 key) object.
+    """
+    if api_key is not None:
+        return APIKey(api_key=api_key)
+    else:
+        # Load from environment variables or .env file
+        try:
+            return APIKey()
+        except (InvalidApiKeyError, ValidationError) as e:
+            try:
+                return APICredential()
+            except Exception:
+                raise InvalidApiKeyError(
+                    "API key is not provided or it's invalid."
+                ) from e

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 
 import numpy as np
@@ -9,8 +8,8 @@ from PIL import Image, ImageChops
 from landingai.predict import OcrPredictor, Predictor
 from landingai.visualize import overlay_predictions
 
-_API_KEY = "v7b0hdyfj6271xy2o9lmiwkkcbdpvt1"
-_API_SECRET = "ao6yjcju7q1e6u0udgwrgknhrx6m4n1o48z81jy6huc059gne047l4fq3u1cgq"
+_API_KEY = "land_sk_aMemWbpd41yXnQ0tXvZMh59ISgRuKNRKjJEIUHnkiH32NBJAwf"
+
 _EXPECTED_VP_PREDS = [
     {
         "label_name": "Green Field",
@@ -52,10 +51,7 @@ def test_od_predict():
     Path("tests/output").mkdir(parents=True, exist_ok=True)
     # Endpoint: https://app.landing.ai/app/376/pr/11165/deployment?device=tiger-team-integration-tests
     endpoint_id = "db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4"
-    # TODO: Replace with v2 API key
-    os.environ["landingai_api_key"] = _API_KEY
-    os.environ["landingai_api_secret"] = _API_SECRET
-    predictor = Predictor(endpoint_id)
+    predictor = Predictor(endpoint_id, api_key=_API_KEY)
     img = np.asarray(Image.open("tests/data/images/cereal1.jpeg"))
     assert img is not None
     # Call LandingLens inference endpoint with Predictor.predict()
@@ -75,18 +71,13 @@ def test_od_predict():
     logging.info(preds)
     img_with_preds = overlay_predictions(predictions=preds, image=img)
     img_with_preds.save("tests/output/test_od.jpg")
-    del os.environ["landingai_api_key"]
-    del os.environ["landingai_api_secret"]
 
 
 def test_seg_predict(expected_seg_prediction, seg_mask_validator):
     Path("tests/output").mkdir(parents=True, exist_ok=True)
     # Project: https://app.landing.ai/app/376/pr/26113016987660/deployment?device=tiger-team-integration-tests
     endpoint_id = "72fdc6c2-20f1-4f5e-8df4-62387acec6e4"
-    # TODO: Replace with v2 API key
-    os.environ["landingai_api_key"] = _API_KEY
-    os.environ["landingai_api_secret"] = _API_SECRET
-    predictor = Predictor(endpoint_id)
+    predictor = Predictor(endpoint_id, api_key=_API_KEY)
     img = Image.open("tests/data/images/cereal1.jpeg")
     assert img is not None
     preds = predictor.predict(img)
@@ -95,18 +86,13 @@ def test_seg_predict(expected_seg_prediction, seg_mask_validator):
     logging.info(preds)
     img_with_masks = overlay_predictions(preds, img)
     img_with_masks.save("tests/output/test_seg.jpg")
-    del os.environ["landingai_api_key"]
-    del os.environ["landingai_api_secret"]
 
 
 def test_vp_predict(seg_mask_validator):
     Path("tests/output").mkdir(parents=True, exist_ok=True)
     # Project: https://app.landing.ai/app/376/pr/26098103179275/deployment?device=tiger-example
     endpoint_id = "63035608-9d24-4342-8042-e4b08e084fde"
-    # TODO: Replace with v2 API key
-    os.environ["landingai_api_key"] = _API_KEY
-    os.environ["landingai_api_secret"] = _API_SECRET
-    predictor = Predictor(endpoint_id)
+    predictor = Predictor(endpoint_id, api_key=_API_KEY)
     img = np.asarray(Image.open("tests/data/images/farm-coverage.jpg"))
     assert img is not None
     preds = predictor.predict(img)
@@ -126,18 +112,13 @@ def test_vp_predict(seg_mask_validator):
     expected = Image.open("tests/data/images/expected_vp_masks.png")
     diff = ImageChops.difference(img_with_masks.resize((512, 512)), expected)
     assert diff.getbbox() is None, "Expected and actual images should be the same"
-    del os.environ["landingai_api_key"]
-    del os.environ["landingai_api_secret"]
 
 
 def test_class_predict():
     Path("tests/output").mkdir(parents=True, exist_ok=True)
     # Project: https://app.landing.ai/app/376/pr/26119078438913/deployment?device=tiger-team-integration-tests
     endpoint_id = "8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43"
-    # TODO: Replace with v2 API key
-    os.environ["landingai_api_key"] = _API_KEY
-    os.environ["landingai_api_secret"] = _API_SECRET
-    predictor = Predictor(endpoint_id)
+    predictor = Predictor(endpoint_id, api_key=_API_KEY)
     img = Image.open("tests/data/images/wildfire1.jpeg")
     assert img is not None
     preds = predictor.predict(img)
@@ -148,8 +129,6 @@ def test_class_predict():
     logging.info(preds)
     img_with_masks = overlay_predictions(preds, img)
     img_with_masks.save("tests/output/test_class.jpg")
-    del os.environ["landingai_api_key"]
-    del os.environ["landingai_api_secret"]
 
 
 # TODO: re-enable below test after OCR endpoint is deployed to prod
@@ -159,88 +138,6 @@ def test_ocr_predict():
     predictor = OcrPredictor(
         # TODO: replace with a prod key after the OCR endpoint is deployed to prod
         api_key="land_sk_6uttU3npa5V0MUgPWb6j33ZuszsGBqVGs4wnoSR91LBwpbjZpG",
-        api_secret="1234",
-    )
-    img = Image.open("tests/data/images/ocr_test.png")
-    assert img is not None
-    # Test multi line
-    preds = predictor.predict(img, mode="multi-text")
-    logging.info(preds)
-    expected_texts = [
-        "公司名称",
-        "业务方向",
-        "Anysphere",
-        "AI工具",
-        "Atomic Semi",
-        "芯片",
-        "Cursor",
-        "代码编辑",
-        "Diagram",
-        "设计",
-        "Harvey",
-        "AI法律顾问",
-        "Kick",
-        "会计软件",
-        "Milo",
-        "家长虚拟助理",
-        "qqbot.dev",
-        "开发者工具",
-        "EdgeDB",
-        "开源数据库",
-        "Mem Labs",
-        "笔记应用",
-        "Speak",
-        "英语学习",
-        "Descript",
-        "音视频编辑",
-        "量子位",
-    ]
-    assert len(preds) == len(expected_texts)
-    for pred, expected in zip(preds, expected_texts):
-        assert pred.text == expected
-
-    img_with_masks = overlay_predictions(preds, img)
-    img_with_masks.save("tests/output/test_ocr_multiline.jpg")
-    # Test single line
-    preds = predictor.predict(
-        img,
-        mode="single-text",
-        regions_of_interest=[
-            [[99, 19], [366, 19], [366, 75], [99, 75]],
-            [[599, 842], [814, 845], [814, 894], [599, 892]],
-        ],
-    )
-    logging.info(preds)
-    expected = [
-        {
-            "text": "公司名称",
-            "location": [(99, 19), (366, 19), (366, 75), (99, 75)],
-            "score": 0.8279303908348083,
-        },
-        {
-            "text": "英语学习",
-            "location": [(599, 842), (814, 845), (814, 894), (599, 892)],
-            "score": 0.939440906047821,
-        },
-    ]
-    for pred, expected in zip(preds, expected):
-        assert pred.text == expected["text"]
-        assert pred.location == expected["location"]
-        assert pred.score == expected["score"]
-    img_with_masks = overlay_predictions(preds, img)
-    img_with_masks.save("tests/output/test_ocr_singleline.jpg")
-    del os.environ["landingai_api_key"]
-    del os.environ["landingai_api_secret"]
-
-
-# TODO: re-enable below test after OCR endpoint is deployed to prod
-@pytest.mark.skip(reason="OCR endpoint is not deployed to prod yet")
-def test_ocr_predict():
-    Path("tests/output").mkdir(parents=True, exist_ok=True)
-    predictor = OcrPredictor(
-        # TODO: replace with a prod key after the OCR endpoint is deployed to prod
-        api_key="land_sk_6uttU3npa5V0MUgPWb6j33ZuszsGBqVGs4wnoSR91LBwpbjZpG",
-        api_secret="1234",
     )
     img = Image.open("tests/data/images/ocr_test.png")
     assert img is not None

--- a/tests/unit/landingai/data_management/test_metadata.py
+++ b/tests/unit/landingai/data_management/test_metadata.py
@@ -2,7 +2,7 @@ import responses
 
 from landingai.data_management.metadata import Metadata
 
-_API_KEY = "v7b0hdyfj6271xy2o9lmiwkkcbdpvt1"
+_API_KEY = "land_sk_12345"
 _PROJECT_ID = 30863867234314
 
 

--- a/tests/unit/landingai/test_common.py
+++ b/tests/unit/landingai/test_common.py
@@ -7,10 +7,52 @@ from pydantic import ValidationError
 
 from landingai.common import (
     APICredential,
+    APIKey,
     ObjectDetectionPrediction,
     SegmentationPrediction,
     decode_bitmap_rle,
 )
+from landingai.exceptions import InvalidApiKeyError
+
+
+def test_load_api_key_from_constructor():
+    key = APIKey(api_key="land_sk_1234")
+    assert key.api_key == "land_sk_1234"
+    with pytest.raises(InvalidApiKeyError):
+        APIKey(api_key="1234")
+
+
+def test_load_api_key_from_env_var():
+    os.environ["landingai_api_key"] = "1234"
+    with pytest.raises(InvalidApiKeyError):
+        APIKey()
+    os.environ["landingai_api_key"] = "land_sk_1234"
+    key = APIKey()
+    assert key.api_key == "land_sk_1234"
+    del os.environ["landingai_api_key"]
+
+
+def test_load_api_key_from_env_file(tmp_path):
+    env_file: Path = tmp_path / ".env"
+    env_file.write_text(
+        """
+                        LANDINGAI_API_KEY="land_sk_2222"
+                        LANDINGAI_API_SECRET="abcd"
+                        """
+    )
+    # Overwrite the default env_prefix to avoid conflict with the real .env
+    APIKey.__config__.env_file = str(env_file)
+    for field in APIKey.__fields__.values():
+        APIKey.__config__.prepare_field(field)
+    # Start testing
+    credential = APIKey(_env_file=str(env_file))
+    assert credential.api_key == "land_sk_2222"
+    env_file.unlink()
+    with pytest.raises(ValidationError):
+        APIKey()
+    # reset back to the default config
+    APIKey.__config__.env_file = ".env"
+    env_file.unlink()
 
 
 def test_load_credential():
@@ -19,6 +61,8 @@ def test_load_credential():
     credential = APICredential()
     assert credential.api_key == "1234"
     assert credential.api_secret == "abcd"
+    del os.environ["landingai_api_key"]
+    del os.environ["landingai_api_secret"]
 
 
 def test_load_credential_from_env_file(tmp_path):

--- a/tests/unit/landingai/test_common.py
+++ b/tests/unit/landingai/test_common.py
@@ -52,7 +52,6 @@ def test_load_api_key_from_env_file(tmp_path):
         APIKey()
     # reset back to the default config
     APIKey.__config__.env_file = ".env"
-    env_file.unlink()
 
 
 def test_load_credential():

--- a/tests/unit/landingai/test_postprocess.py
+++ b/tests/unit/landingai/test_postprocess.py
@@ -12,7 +12,7 @@ def test_segmentation_class_pixel_coverage():
         file_path="tests/data/responses/default_vp_model_response.yaml"
     )
     endpoint_id = "63035608-9d24-4342-8042-e4b08e084fde"
-    predictor = Predictor(endpoint_id, "fake_key_12345", "fake_secret_12345")
+    predictor = Predictor(endpoint_id, api_key="land_sk_12345")
     img = np.asarray(Image.open("tests/data/images/farm-coverage.jpg"))
     predictions = []
     for img in [img] * 3:

--- a/tests/unit/landingai/test_predict.py
+++ b/tests/unit/landingai/test_predict.py
@@ -355,7 +355,6 @@ def test_load_api_credential_from_env_file(tmp_path):
     env_file.write_text(
         """
                         LANDINGAI_API_KEY="land_sk_12345"
-                        LANDINGAI_API_SECRET="abcd"
                         """
     )
     # Overwrite the default env_prefix to avoid conflict with the real .env

--- a/tests/unit/landingai/test_utils.py
+++ b/tests/unit/landingai/test_utils.py
@@ -1,0 +1,47 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from landingai.common import APIKey
+from landingai.exceptions import InvalidApiKeyError
+from landingai.utils import load_api_credential
+
+
+def test_load_api_credential_invalid_key():
+    with pytest.raises(InvalidApiKeyError):
+        load_api_credential()
+    with pytest.raises(InvalidApiKeyError):
+        load_api_credential(api_key="fake_key")
+    with pytest.raises(InvalidApiKeyError):
+        os.environ["landingai_api_key"] = "1234"
+        load_api_credential()
+
+
+def test_load_api_credential_from_constructor():
+    actual = load_api_credential(api_key="land_sk_1234")
+    assert actual.api_key == "land_sk_1234"
+
+
+def test_load_api_credential_from_env_var():
+    os.environ["landingai_api_key"] = "land_sk_123"
+    actual = load_api_credential()
+    assert actual.api_key == "land_sk_123"
+    del os.environ["landingai_api_key"]
+
+
+def test_load_api_credential_from_env_file(tmp_path):
+    env_file: Path = tmp_path / ".env"
+    env_file.write_text(
+        """
+                        LANDINGAI_API_KEY="land_sk_12345"
+                        LANDINGAI_API_SECRET="abcd"
+                        """
+    )
+    # Overwrite the default env_prefix to avoid conflict with the real .env
+    APIKey.__config__.env_file = str(env_file)
+    actual = load_api_credential()
+    assert actual.api_key == "land_sk_12345"
+    # reset back to the default config
+    APIKey.__config__.env_file = ".env"
+    env_file.unlink()

--- a/tests/unit/landingai/test_utils.py
+++ b/tests/unit/landingai/test_utils.py
@@ -35,7 +35,6 @@ def test_load_api_credential_from_env_file(tmp_path):
     env_file.write_text(
         """
                         LANDINGAI_API_KEY="land_sk_12345"
-                        LANDINGAI_API_SECRET="abcd"
                         """
     )
     # Overwrite the default env_prefix to avoid conflict with the real .env


### PR DESCRIPTION
The LandingLens platform released a new version of the API key (i.e. v2). This PR supports the new API key v2.
(The current v1 key requires the end users to copy two strings which creates friction, the v2 key only has one key string.)

**Main changes**

1. Introduced a new `APIKey` class
2. [**Breaking**]Removed the `api_secret` parameter in `Predictor` class
3. [**Breaking**]Made the `api_key` parameter as a named parameter.
4. Updated `_load_api_credential()` to support both API key v1 and v2.

After this PR, API key v1 can only be configured via env vars or `.env` file, i.e. it can't be passed to Predictor via constructor.

## Migration Guide

Below section shows you how to fix the backward incompatible changes when you upgrade the version to `0.1.0`.

1. Generate your v2 API key from LandingLens. See [here](https://support.landing.ai/docs/api-key) for more information.
2. The `api_secret` parameter is removed in the `Predictor` and `OcrPredictor` class. `api_key` is a named parameter now, which means you must specify the parameter name, i.e. `api_key` if you want to pass it `Predictor` as an argument.  See below code as an example:
    **Before upgrade to `0.1.0`**
    ```
    predictor = Predictor(endpoint_id, api_key, api_secret)
    ```
    **After upgrade to `0.1.0`**
    ```
    predictor = Predictor(endpoint_id, api_key=api_key)
    ```

