### PR TITLE
[skip release]Add a flag to skip release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -50,7 +50,7 @@ jobs:
   Release:
     needs: Test
     # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):') && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v4


### PR DESCRIPTION
Every PR/commit will trigger a release to PyPI currently.
For breaking changes, it's better to bundle those commits together as a single release to reduce the impact and improve the developer experience.
Thus introduce a flag "[skip release]" which skips the "Release" step if the PR title includes such a string.