### PR TITLE
Only support v2 API key

### DIFF
--- a/examples/apps/ocr/app.py
+++ b/examples/apps/ocr/app.py
@@ -12,7 +12,7 @@ from roi import draw_region_of_interests, process_and_display_roi
 
 from landingai.predict import OcrPredictor, serialize_rois
 from landingai.st_utils import (
-    get_api_credential_or_use_default,
+    get_api_key_or_use_default,
     get_default_api_key,
     render_api_config_form,
     render_svg,
@@ -97,13 +97,13 @@ def main():
             key="th_slider",
         )
         mode = DetModel[detection_mode].value
-        key, secret = get_api_credential_or_use_default()
+        key = get_api_key_or_use_default()
         # Run ocr on the whole image
         if input_images is not None and st.button("Run"):
             predictor = OcrPredictor(
                 threshold=float(threshold),
                 api_key=key,
-                api_secret=secret,
+                api_secret="",
             )
             begin = time.perf_counter()
             logging.info(
@@ -126,14 +126,13 @@ def main():
                 ]
             st.json(json_result)
 
-        _render_curl_command(mode, boxes, key, secret)
+        _render_curl_command(mode, boxes, key)
 
 
 def _render_curl_command(
     mode: str,
     rois: Optional[List[List[int]]] = None,
     api_key: Optional[str] = None,
-    api_secret: Optional[str] = None,
 ) -> str:
     st.divider()
     # Build curl command str
@@ -143,17 +142,15 @@ def _render_curl_command(
      --header 'apikey: YOUR_API_KEY' \\"""
     if api_key and api_key != get_default_api_key():
         curl_command_str = curl_command_str.replace("YOUR_API_KEY", api_key)
-    if api_secret:
-        curl_command_str += f"\n     --header 'apisecret: {api_secret}' \\"
     if rois:
         curl_command_str += f"\n     --form 'rois={serialize_rois(rois, mode)}' \\"
     curl_command_str += "\n     --form 'images=@\"YOUR_FILE_PATH\"'"
     # Display curl command
-    st.subheader("curl command")
+    st.subheader("Run Inference with cURL command")
     st.caption(
         """Instructions for composing a valid curl command:
- 1. enter your api key in the sidebar.
- 2. replace 'YOUR_FILE_PATH' with the path to your local image file."""
+ 1. Enter your api key in the sidebar.
+ 2. Replace 'YOUR_FILE_PATH' with the path to your local image file."""
     )
     st.code(curl_command_str)
 

--- a/examples/apps/ocr/roi.py
+++ b/examples/apps/ocr/roi.py
@@ -16,7 +16,7 @@ def draw_region_of_interests(image: PIL.Image.Image) -> Dict[str, Any]:
     st.sidebar.write(
         "To draw 4 point polygon left click and draw 3 edges (must in **clockwise order**) and then right click for the 4th point to close the polygon"
     )
-    mode = "polygon" if st.sidebar.checkbox("4 point polygon", False) else "rect"
+    mode = "polygon" if st.sidebar.checkbox("4 point polygon (ONLY in Desktop Browser)", False) else "rect"
     img_width, img_height = image.size
     st.write(
         "Draw as many boxes as needed in the image below to read the text inside those boxes"

--- a/examples/apps/ocr/roi.py
+++ b/examples/apps/ocr/roi.py
@@ -16,7 +16,11 @@ def draw_region_of_interests(image: PIL.Image.Image) -> Dict[str, Any]:
     st.sidebar.write(
         "To draw 4 point polygon left click and draw 3 edges (must in **clockwise order**) and then right click for the 4th point to close the polygon"
     )
-    mode = "polygon" if st.sidebar.checkbox("4 point polygon (ONLY in Desktop Browser)", False) else "rect"
+    mode = (
+        "polygon"
+        if st.sidebar.checkbox("4 point polygon (ONLY in Desktop Browser)", False)
+        else "rect"
+    )
     img_width, img_height = image.size
     st.write(
         "Draw as many boxes as needed in the image below to read the text inside those boxes"

--- a/landingai/st_utils.py
+++ b/landingai/st_utils.py
@@ -99,7 +99,7 @@ def get_api_key_or_use_default() -> Optional[str]:
     If the API key is not set in the session state, it will look for the default API key from environment variables.
     """
     st = _import_st()
-    key = st.session_state["api_key"]
+    key: str = st.session_state["api_key"]
     if not key:
         return get_default_api_key()
     return key

--- a/landingai/st_utils.py
+++ b/landingai/st_utils.py
@@ -3,7 +3,7 @@ It's only intended for the example streamlit Apps. When using the SDK in your ow
 """
 import logging
 import os
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 _DEFAULT_API_KEY_ENV_VAR = "LANDINGAI_API_KEY"
 
@@ -33,7 +33,7 @@ def setup_page(page_title: str) -> None:
     level = os.environ.get("LOGLEVEL", "INFO").upper()
     logging.basicConfig(
         level=level,
-        format="%(asctime)s %(filename)s %(funcName)s %(message)s",
+        format="%(asctime)s [%(levelname)s][%(filename)s] %(funcName)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     st = _import_st()
@@ -79,12 +79,9 @@ def check_api_credentials_set() -> None:
     st = _import_st()
     api_key = st.session_state.get("api_key")
     if api_key:
-        if api_key.startswith("land_sk_"):
-            return  # non-empty v2 api key
-        elif st.session_state.get("api_secret"):
-            return  # non-empty v1 api key and secret
+        return
 
-    st.error("Please open the sidebar and enter your API credential first.")
+    st.error("Please open the sidebar and enter your API key first.")
     st.stop()
 
 
@@ -97,16 +94,15 @@ def check_endpoint_id_set() -> None:
     st.stop()
 
 
-def get_api_credential_or_use_default() -> Tuple[Optional[str], Optional[str]]:
-    """Get API credential (api key and api secret) from the session state.
-    If the API credential is not set in the session state, use the default API credential from environment variables.
-    The output could be either a v1 API key and secret, or a v2 API key depends on what is set in the session state.
+def get_api_key_or_use_default() -> Optional[str]:
+    """Get API key (v2) from the session state.
+    If the API key is not set in the session state, it will look for the default API key from environment variables.
     """
     st = _import_st()
-    key, secret = (st.session_state["api_key"], st.session_state["api_secret"])
+    key = st.session_state["api_key"]
     if not key:
-        return get_default_api_key(), secret
-    return key, secret
+        return get_default_api_key()
+    return key
 
 
 def get_default_api_key() -> Optional[str]:
@@ -123,7 +119,6 @@ def get_default_api_key() -> Optional[str]:
 def render_api_config_form(
     render_endpoint_id: bool = False,
     default_key: str = "",
-    default_secret: str = "",
     default_endpoint_id: str = "",
 ) -> None:
     """Show API credential and endpoint ID (optionally) configuration form.
@@ -136,16 +131,13 @@ def render_api_config_form(
     # Set a default value in session state for the first time
     if "api_key" not in st.session_state:
         st.session_state["api_key"] = default_key
-    if "api_secret" not in st.session_state:
-        st.session_state["api_secret"] = default_secret
     if "endpoint_id" not in st.session_state:
         st.session_state["endpoint_id"] = default_endpoint_id
 
     def _update_credential(
-        api_key: str, api_secret: str, endpoint_id: Optional[str]
+        api_key: str, endpoint_id: Optional[str]
     ) -> None:
         st.session_state["api_key"] = api_key
-        st.session_state["api_secret"] = api_secret
         if endpoint_id:
             st.session_state["endpoint_id"] = endpoint_id
 
@@ -157,12 +149,6 @@ def render_api_config_form(
             help="If left empty, the free trial API key is used. The default key is a free trial key with a rate limit, i.e. X times per day.",
             type="password",
         )
-        api_secret = st.text_input(
-            "LandingLens API Secret",
-            key="lnd_api_secret",
-            value=st.session_state["api_secret"],
-            help="Leave it empty if you use a v2 API key. Only the legacy API key (i.e. v1) requires API secret. The v2 API key always starts with 'land_sk_'.",
-        )
         endpoint_id = None
         if render_endpoint_id:
             endpoint_id = st.text_input(
@@ -173,9 +159,9 @@ def render_api_config_form(
 
         submitted = st.form_submit_button("Save")
         if submitted:
-            _update_credential(api_key, api_secret, endpoint_id)
-            st.info("API configuration is saved successfully")
+            _update_credential(api_key, endpoint_id)
+            st.info("API key is saved successfully")
 
-    key, _ = get_api_credential_or_use_default()
+    key = get_api_key_or_use_default()
     if key == get_default_api_key():
         st.info("The default API key (free trial) is used")

--- a/landingai/st_utils.py
+++ b/landingai/st_utils.py
@@ -134,9 +134,7 @@ def render_api_config_form(
     if "endpoint_id" not in st.session_state:
         st.session_state["endpoint_id"] = default_endpoint_id
 
-    def _update_credential(
-        api_key: str, endpoint_id: Optional[str]
-    ) -> None:
+    def _update_credential(api_key: str, endpoint_id: Optional[str]) -> None:
         st.session_state["api_key"] = api_key
         if endpoint_id:
             st.session_state["endpoint_id"] = endpoint_id


### PR DESCRIPTION
Changes

1. Remove the API secret input box from the Streamlit API key form UI component, i.e. **support V2 API key only**.
2. Polish a few wordings in the OCR app