### PR TITLE
Tighten dependency versions for better stability

### DIFF
--- a/landingai/st_utils.py
+++ b/landingai/st_utils.py
@@ -29,6 +29,10 @@ If you are running one of the example Apps of this repo, please follow the insta
 def setup_page(page_title: str) -> None:
     """Common setup code for streamlit pages.
     This function should be called only once at the beginning of the page.
+    Commoon setup includes:
+    1. Set page title and favicon
+    2. Set up logging configuration
+    3. Hide the default streamlit menu button and footer
     """
     level = os.environ.get("LOGLEVEL", "INFO").upper()
     logging.basicConfig(

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,8 +864,10 @@ files = [
 ]
 
 [package.dependencies]
+imageio-ffmpeg = {version = "*", optional = true, markers = "extra == \"ffmpeg\""}
 numpy = "*"
 pillow = ">=8.3.2"
+psutil = {version = "*", optional = true, markers = "extra == \"ffmpeg\""}
 
 [package.extras]
 all-plugins = ["astropy", "av", "imageio-ffmpeg", "psutil", "tifffile"]
@@ -1802,12 +1804,12 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.21.0", markers = "python_version <= \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
-    {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
-    {version = ">=1.17.0", markers = "python_version >= \"3.7\""},
-    {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
     {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
     {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
+    {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
+    {version = ">=1.17.0", markers = "python_version >= \"3.7\""},
+    {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
 ]
 
 [[package]]
@@ -1829,12 +1831,12 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.21.0", markers = "python_version <= \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
-    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
-    {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
-    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
     {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
     {version = ">=1.17.0", markers = "python_version >= \"3.7\""},
     {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
+    {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
 ]
 
 [[package]]
@@ -3123,5 +3125,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8"
-content-hash = "aabd0a2634d922201753186082550f365ba114ce00bb8b936bc695d266595252"
+python-versions = ">=3.8,<4.0"
+content-hash = "9c488ec26f648031264c459a1996816de08839828dfbd9fbf0a8f041d723f239"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,26 +16,25 @@ packages = [{include = "landingai"}]
 "documentation" = "https://landing-ai.github.io/landingai-python/landingai.html"
 
 [tool.poetry.dependencies]  # main dependency group
-python = ">=3.8"
+python = ">=3.8,<4.0"
 
-opencv-python = ">=4.5"
-numpy = ">=1.21.0"
-pillow = "^9" # Version 10.0.0 had a issue on FreeTypeFont that will be fixed on the next release 
-pydantic = { version = "^1", extras = ["dotenv"] } # Version 2 has breaking changes (in particular to seetings)
-requests = "*"
+opencv-python = ">=4.5,<5.0"
+numpy = ">=1.21.0,<2.0.0"
+pillow = "9.*" # Version 10.0.0 had a issue on FreeTypeFont that will be fixed on the next release 
+pydantic = { version = "1.*", extras = ["dotenv"] } # Version 2 has breaking changes (in particular to seetings)
+requests = "2.*"
 snowflake-connector-python = "3.0.*"
 bbox-visualizer = "^0.1.0"
 segmentation-mask-overlay = "^0.3.4"
-imageio = "*"
-imageio-ffmpeg = "*"
+imageio = { version = "2.*", extras = ["ffmpeg"] }
 
 [tool.poetry.group.dev.dependencies]
-autoflake = "*"
-pytest = "*"
-black = "*"
-flake8 = "^5"
-isort = "*"
-pdoc = "*"
+autoflake = "1.*"
+pytest = "7.*"
+black = "23.*"
+flake8 = "5.*"
+isort = "5.*"
+pdoc = "14.*"
 responses = "^0.23.1"
 mypy = "^1.3.0"
 types-requests = "^2.31.0.0"
@@ -45,7 +44,7 @@ testbook = "^0.4.2"
 
 
 [tool.poetry.group.examples.dependencies]
-jupyterlab = "*"
+jupyterlab = "4.*"
 
 [tool.pytest.ini_options]
 log_cli = true


### PR DESCRIPTION
The current version constraints could cause a major version bump for some of our dependencies, which could break our library code.
This PR adds more constraints to tighten the upper bound of the version constraints.