### PR TITLE
feat(data_management): support loading API key from env vars or .env file

### DIFF
--- a/landingai/data_management/client.py
+++ b/landingai/data_management/client.py
@@ -77,9 +77,9 @@ class LandingLens:
 
     Parameters
     ----------
-    project-id: str
+    project_id: int
         LandingLens project id.  Can override this default in individual commands.
-    api-key: Optional[str]
+    api_key: Optional[str]
         LandingLens API Key. If it's not provided, it will be read from the environment variable LANDINGAI_API_KEY, or from .env file on your project root directory.
     """
 

--- a/landingai/data_management/client.py
+++ b/landingai/data_management/client.py
@@ -10,6 +10,7 @@ import requests
 
 from landingai.data_management.utils import to_camel_case
 from landingai.exceptions import HttpError
+from landingai.utils import load_api_credential
 
 METADATA_ITEMS = "metadata_items"
 METADATA_UPDATE = "metadata_update"
@@ -72,22 +73,20 @@ class LandingLens:
     Example
     -------
     # Create a client by specifying API Key and project id
-    >>> client = LandingLens(api_key, project)
+    >>> client = LandingLens(project, api_key)
 
     Parameters
     ----------
-    api-key : str
-        LandingLens API Key.
     project-id: str
         LandingLens project id.  Can override this default in individual commands.
+    api-key: Optional[str]
+        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDING_LENS_API_KEY, or from .env file on your project root directory.
     """
 
-    def __init__(
-        self,
-        api_key: str,
-        project_id: int,
-    ):
+    def __init__(self, project_id: int, api_key: Optional[str] = None):
         self.project_id = project_id
+        if not api_key:
+            api_key = load_api_credential().api_key
         self.api_key = api_key
 
     @property

--- a/landingai/data_management/client.py
+++ b/landingai/data_management/client.py
@@ -80,7 +80,7 @@ class LandingLens:
     project-id: str
         LandingLens project id.  Can override this default in individual commands.
     api-key: Optional[str]
-        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDING_LENS_API_KEY, or from .env file on your project root directory.
+        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDINGAI_API_KEY, or from .env file on your project root directory.
     """
 
     def __init__(self, project_id: int, api_key: Optional[str] = None):

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -49,10 +49,22 @@ class Media:
     """Media management API client.
     This class provides a set of APIs to manage the medias (images) uploaded to LandingLens.
     For example, you can use this class to upload medias (images) to LandingLens or list the medias are already uploaded to the LandingLens.
+
+    Example
+    -------
+    # Create a Media client by specifying API Key and project id
+    >>> client = Media(project_id, api_key)
+
+    Parameters
+    ----------
+    project-id: str
+        LandingLens project id.  Can override this default in individual commands.
+    api-key: Optional[str]
+        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDING_LENS_API_KEY, or from .env file on your project root directory.
     """
 
-    def __init__(self, api_key: str, project_id: int):
-        self._client = LandingLens(api_key=api_key, project_id=project_id)
+    def __init__(self, project_id: int, api_key: Optional[str] = None):
+        self._client = LandingLens(project_id=project_id, api_key=api_key)
         self._media_max_page_size = 1000
         self._metadata_max_page_size = 500
 

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -60,7 +60,7 @@ class Media:
     project-id: str
         LandingLens project id.  Can override this default in individual commands.
     api-key: Optional[str]
-        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDING_LENS_API_KEY, or from .env file on your project root directory.
+        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDINGAI_API_KEY, or from .env file on your project root directory.
     """
 
     def __init__(self, project_id: int, api_key: Optional[str] = None):

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -57,9 +57,9 @@ class Media:
 
     Parameters
     ----------
-    project-id: str
+    project_id: int
         LandingLens project id.  Can override this default in individual commands.
-    api-key: Optional[str]
+    api_key: Optional[str]
         LandingLens API Key. If it's not provided, it will be read from the environment variable LANDINGAI_API_KEY, or from .env file on your project root directory.
     """
 

--- a/landingai/data_management/metadata.py
+++ b/landingai/data_management/metadata.py
@@ -12,10 +12,22 @@ class Metadata:
     """Metadata management API client.
     This class provides a set of APIs to manage the metadata of the medias (images) uploaded to LandingLens.
     For example, you can use this class to update the metadata of the uploaded medias.
+
+    Example
+    -------
+    # Create a Metadata client by specifying API Key and project id
+    >>> client = Metadata(project_id, api_key)
+
+    Parameters
+    ----------
+    project-id: str
+        LandingLens project id.  Can override this default in individual commands.
+    api-key: Optional[str]
+        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDING_LENS_API_KEY, or from .env file on your project root directory.
     """
 
-    def __init__(self, api_key: str, project_id: int):
-        self._client = LandingLens(api_key=api_key, project_id=project_id)
+    def __init__(self, project_id: int, api_key: Optional[str] = None):
+        self._client = LandingLens(project_id=project_id, api_key=api_key)
 
     def update(
         self,

--- a/landingai/data_management/metadata.py
+++ b/landingai/data_management/metadata.py
@@ -20,9 +20,9 @@ class Metadata:
 
     Parameters
     ----------
-    project-id: str
+    project_id: int
         LandingLens project id.  Can override this default in individual commands.
-    api-key: Optional[str]
+    api_key: Optional[str]
         LandingLens API Key. If it's not provided, it will be read from the environment variable LANDINGAI_API_KEY, or from .env file on your project root directory.
     """
 

--- a/landingai/data_management/metadata.py
+++ b/landingai/data_management/metadata.py
@@ -23,7 +23,7 @@ class Metadata:
     project-id: str
         LandingLens project id.  Can override this default in individual commands.
     api-key: Optional[str]
-        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDING_LENS_API_KEY, or from .env file on your project root directory.
+        LandingLens API Key. If it's not provided, it will be read from the environment variable LANDINGAI_API_KEY, or from .env file on your project root directory.
     """
 
     def __init__(self, project_id: int, api_key: Optional[str] = None):

--- a/tests/unit/landingai/data_management/test_media.py
+++ b/tests/unit/landingai/data_management/test_media.py
@@ -23,7 +23,7 @@ def test_single_file_upload(mocked_aioresponse, tmp_path):
         file_path="tests/data/responses/v1_media_upload_single_file.yaml"
     )
     _setup_aio_mocks(["image_1688427395107.jpeg"], mocked_aioresponse)
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     file_name, img_path = _write_random_test_image(
         tmp_path, file_name="image_1688427395107.jpeg"
     )
@@ -59,7 +59,7 @@ def test_folder_upload_with_subdirectories_skip_txt(mocked_aioresponse, tmp_path
         ],
         mocked_aioresponse,
     )
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     _write_random_test_image_folder(tmp_path, num_images=1)
     _write_random_test_image_folder(tmp_path / "subdir", num_images=2)
     upload_resp = media.upload(tmp_path)
@@ -138,7 +138,7 @@ def test_ls_filter_by_split():
     responses._add_from_file(
         file_path="tests/data/responses/v1_media_list_filter_by_split.yaml"
     )
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     resp = media.ls(split="dev")
     medias = resp["medias"]
     assert len(medias) == 2
@@ -149,7 +149,7 @@ def test_ls_media_statuses_filter_by_one_status():
     responses._add_from_file(
         file_path="tests/data/responses/v1_media_list_by_one_status.yaml"
     )
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     output = media.ls(media_status="raw")
     assert len(output["medias"]) >= 10
 
@@ -159,13 +159,13 @@ def test_ls_media_statuses_mixed_ordering():
     responses._add_from_file(
         file_path="tests/data/responses/v1_media_list_by_three_status.yaml"
     )
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     output = media.ls(media_status=["raw", "approved", "in_task"])
     assert len(output["medias"]) >= 10
 
 
 def test_ls_pagination_step_exceeds_max():
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     media._media_max_page_size = 2
     media._metadata_max_page_size = 1
     with pytest.raises(ValueError) as e:
@@ -174,7 +174,7 @@ def test_ls_pagination_step_exceeds_max():
 
 
 def test_ls_not_allowed_media_status():
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     with pytest.raises(ValueError) as e:
         media.ls(media_status="sth_wrong")
     assert (
@@ -184,7 +184,7 @@ def test_ls_not_allowed_media_status():
 
 
 def test_ls_not_allowed_media_status_list_with_one_wrong():
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     with pytest.raises(ValueError) as e:
         media.ls(media_status=["raw", "pending_sth_wrong"])
     assert (
@@ -194,7 +194,7 @@ def test_ls_not_allowed_media_status_list_with_one_wrong():
 
 
 def test_ls_not_allowed_media_status_empty_list():
-    media = Media(_API_KEY, _PROJECT_ID)
+    media = Media(_PROJECT_ID, _API_KEY)
     with pytest.raises(ValueError) as e:
         media.ls(media_status=[])
     assert (

--- a/tests/unit/landingai/data_management/test_metadata.py
+++ b/tests/unit/landingai/data_management/test_metadata.py
@@ -11,7 +11,7 @@ def test_set_metadata_for_single_media():
     responses._add_from_file(
         file_path="tests/data/responses/v1_set_metadata_single_media.yaml"
     )
-    metadata = Metadata(_API_KEY, _PROJECT_ID)
+    metadata = Metadata(_PROJECT_ID, _API_KEY)
     resp = metadata.update(10300467, split="train")
     assert resp["project_id"] == _PROJECT_ID
     assert len(resp["media_ids"]) == 1
@@ -26,7 +26,7 @@ def test_set_metadata_for_multiple_media():
         file_path="tests/data/responses/v1_set_metadata_multiple_medias.yaml"
     )
     media_ids = [10300467, 10300466, 10300465]
-    metadata = Metadata(_API_KEY, _PROJECT_ID)
+    metadata = Metadata(_PROJECT_ID, _API_KEY)
     resp = metadata.update(media_ids, creator="tom")
     assert resp["project_id"] == _PROJECT_ID
     assert resp["media_ids"] == media_ids


### PR DESCRIPTION
# Changes

Support loading API credentials from env vars or .env files for `Media` and `Metadata` clients.
In addition, make the `api_key` parameter optional in `Media` and `Metadata` classes.