### PR TITLE
feat(postprocess): support cropping images by OD bboxes

### DIFF
--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -52,8 +52,10 @@ class Media:
 
     Example
     -------
-    # Create a Media client by specifying API Key and project id
     >>> client = Media(project_id, api_key)
+    >>> client.upload("path/to/image.jpg")
+    >>> client.upload("path/to/image_folder")
+    >>> print(client.ls())
 
     Parameters
     ----------
@@ -102,7 +104,7 @@ class Media:
             Set the media's label as OK, valid for object detection and segmetation project
         metadata_dict: dict
             A dictionary of metadata to be updated or inserted.
-            The key of the metadata needs to be created/registered (for the first time) before media uploading.
+            The key of the metadata needs to be created/registered (for the first time) on LandingLens before media uploading.
         validate_extensions: bool
             Defaults to True. Files other than jpg/jpeg/png/bmp will be skipped.
             If set to False, will try to upload all files. Behavior of platform

--- a/landingai/data_management/metadata.py
+++ b/landingai/data_management/metadata.py
@@ -15,8 +15,8 @@ class Metadata:
 
     Example
     -------
-    # Create a Metadata client by specifying API Key and project id
     >>> client = Metadata(project_id, api_key)
+    >>> client.update([101, 102, 103], creator="tom")
 
     Parameters
     ----------
@@ -42,7 +42,7 @@ class Metadata:
             Media ids to update.
         input_metadata
             A dictionary of metadata to be updated or inserted.
-            The key of the metadata needs to be created/registered (for the first time) before media uploading.
+            The key of the metadata needs to be created/registered (for the first time) on LandingLens before calling update().
 
         Returns
         ----------

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -3,11 +3,45 @@ from collections import defaultdict
 from itertools import groupby
 from typing import Dict, List, Sequence, Tuple, Union, cast
 
+import numpy as np
+import PIL.Image
+from PIL.Image import Image
+
 from landingai.common import (
     ClassificationPrediction,
     ObjectDetectionPrediction,
+    Prediction,
     SegmentationPrediction,
 )
+
+
+def crop(
+    predictions: Sequence[Prediction], image: Union[np.ndarray, Image]
+) -> Sequence[Image]:
+    """Crop the image based on the bounding boxes in the predictions.
+
+    Parameters
+    ----------
+    predictions: a list of ObjectDetectionPrediction, each of which will be used to crop the image.
+    image: the input image to be cropped from.
+
+    Returns
+    -------
+    A list of cropped images.
+    """
+    if len(predictions) == 0:
+        return []
+    if isinstance(image, np.ndarray):
+        image = PIL.Image.fromarray(image)
+    output = []
+    for pred in predictions:
+        if not isinstance(pred, ObjectDetectionPrediction):
+            raise ValueError(
+                f"Only ObjectDetectionPrediction is supported but {type(pred)} is found."
+            )
+        xmin, ymin, xmax, ymax = pred.bboxes
+        output.append(image.crop((ymin, xmin, ymax, xmax)))
+    return output
 
 
 def class_map(predictions: Sequence[ClassificationPrediction]) -> Dict[int, str]:

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -39,8 +39,7 @@ def crop(
             raise ValueError(
                 f"Only ObjectDetectionPrediction is supported but {type(pred)} is found."
             )
-        xmin, ymin, xmax, ymax = pred.bboxes
-        output.append(image.crop((ymin, xmin, ymax, xmax)))
+        output.append(image.crop(pred.bboxes))
     return output
 
 

--- a/tests/unit/landingai/test_postprocess.py
+++ b/tests/unit/landingai/test_postprocess.py
@@ -1,4 +1,5 @@
 import numpy as np
+import PIL.Image
 import pytest
 import responses
 from PIL import Image
@@ -28,9 +29,9 @@ def test_segmentation_class_pixel_coverage():
 
 
 def test_crop():
-    img = np.zeros((100, 50, 3), dtype=np.uint8)
-    img[40:60, 20:30, :] = 255
-    img[90:95, 40:45, :] = 254
+    img = np.zeros((50, 100, 3), dtype=np.uint8)
+    img[20:31, 40:61, :] = 255
+    img[40:51, 90:96, :] = 254
     preds = [
         ObjectDetectionPrediction(
             score=0.9, label_name="A", label_index=1, id="1", bboxes=(40, 20, 60, 30)
@@ -40,10 +41,10 @@ def test_crop():
         ),
     ]
     output = crop(preds, img)
-    assert output[0].size == (10, 20)
+    assert output[0].size == (20, 10)
     assert np.count_nonzero(np.asarray(output[0])) == 20 * 10 * 3
-    assert output[1].size == (10, 5)
-    assert np.count_nonzero(np.asarray(output[1])) == 5 * 5 * 3
+    assert output[1].size == (5, 10)
+    assert np.count_nonzero(np.asarray(output[1])) == 5 * 10 * 3
     # Empty preds should return empty list
     assert crop([], img) == []
 

--- a/tests/unit/landingai/test_postprocess.py
+++ b/tests/unit/landingai/test_postprocess.py
@@ -1,5 +1,4 @@
 import numpy as np
-import PIL.Image
 import pytest
 import responses
 from PIL import Image


### PR DESCRIPTION
# Motivation

When processing large image files, e.g. 800MB, 10K * 10K resolution, we need a way to slice the large image into small patches. On LandingLens, we can train a OD model as a cropping tool to crop images in a more robust way than rule-based. (This approach was suggested by our MLE).

This PR supports such a pattern: use OD prediction result to crop an image as a post processing function, it will help with one of our customers.

# Changes

1. Introduce a new `crop()` function in `postprocess.py`
2. Minor updates to the API docs of Media and Metadata classes.