### PR TITLE
feat(predict): track lib version and runtime

### DIFF
--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -706,9 +706,9 @@ def _do_inference(
 
 def _add_defualt_query_params(payload: Dict[str, Any]) -> None:
     """Add default query params to the payload for tracking and analystics purppose."""
+    env_info = get_runtime_environment_info()
+    payload["runtime"] = env_info["runtime"]
     if is_running_in_pytest():
         # Don't add extra query params if pytest is running, otherwise it will fail some unit tests
         return
-    env_info = get_runtime_environment_info()
     payload["lib_version"] = env_info["lib_version"]
-    payload["runtime"] = env_info["runtime"]

--- a/landingai/telemetry.py
+++ b/landingai/telemetry.py
@@ -1,0 +1,77 @@
+"""This module contains the telemetry configuration and APIs for the landingai package (intented for internal use only)."""
+
+
+import os
+import platform
+import sys
+from functools import lru_cache
+from importlib.metadata import version
+from pathlib import Path
+from typing import Dict
+
+
+@lru_cache(maxsize=None)
+def get_runtime_environment_info() -> Dict[str, str]:
+    """Return a set of runtime environment information in key value pairs."""
+    return {
+        "lib_type": "pylib",
+        "lib_version": version("landingai"),
+        "python_version": platform.python_version(),
+        "os": platform.platform(),
+        "runtime": _resolve_python_runtime(),
+    }
+
+
+@lru_cache(maxsize=None)
+def is_running_in_pytest():
+    """Return True if the code is running in a pytest session."""
+    # See: https://stackoverflow.com/questions/25188119/test-if-code-is-executed-from-within-a-py-test-session
+    return "pytest" in sys.modules
+
+
+def _resolve_python_runtime() -> str:
+    if _is_running_in_colab():
+        runtime = "colab"
+    elif _is_running_in_notebook():
+        runtime = "notebook"
+    elif _is_running_in_streamlit():
+        runtime = "streamlit"
+    elif is_running_in_pytest():
+        runtime = "pytest"
+    else:
+        runtime = Path(os.environ.get("_", "unknown")).name
+    return runtime
+
+
+def _is_running_in_colab() -> bool:
+    """Return True if the code is running in a Google Colab notebook."""
+    try:
+        return get_ipython().__class__.__module__ == "google.colab._shell"
+    except NameError:
+        return False  # Probably standard Python interpreter
+
+
+def _is_running_in_notebook() -> bool:
+    """Return True if the code is running in a Jupyter notebook."""
+    try:
+        # See: https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False  # Probably standard Python interpreter
+
+
+def _is_running_in_streamlit() -> bool:
+    """Return True if the code is running in a streamlit App."""
+    # See: https://discuss.streamlit.io/t/how-to-check-if-code-is-run-inside-streamlit-and-not-e-g-ipython/23439/2
+    try:
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+        return get_script_run_ctx() is not None
+    except ImportError:
+        return False

--- a/landingai/telemetry.py
+++ b/landingai/telemetry.py
@@ -55,7 +55,7 @@ def _is_running_in_notebook() -> bool:
     """Return True if the code is running in a Jupyter notebook."""
     try:
         # See: https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
-        shell = get_ipython().__class__.__name__    # type: ignore
+        shell = get_ipython().__class__.__name__  # type: ignore
         if shell == "ZMQInteractiveShell":
             return True  # Jupyter notebook or qtconsole
         elif shell == "TerminalInteractiveShell":

--- a/landingai/telemetry.py
+++ b/landingai/telemetry.py
@@ -23,7 +23,7 @@ def get_runtime_environment_info() -> Dict[str, str]:
 
 
 @lru_cache(maxsize=None)
-def is_running_in_pytest():
+def is_running_in_pytest() -> bool:
     """Return True if the code is running in a pytest session."""
     # See: https://stackoverflow.com/questions/25188119/test-if-code-is-executed-from-within-a-py-test-session
     return "pytest" in sys.modules
@@ -46,7 +46,7 @@ def _resolve_python_runtime() -> str:
 def _is_running_in_colab() -> bool:
     """Return True if the code is running in a Google Colab notebook."""
     try:
-        return get_ipython().__class__.__module__ == "google.colab._shell"
+        return get_ipython().__class__.__module__ == "google.colab._shell"  # type: ignore
     except NameError:
         return False  # Probably standard Python interpreter
 
@@ -55,7 +55,7 @@ def _is_running_in_notebook() -> bool:
     """Return True if the code is running in a Jupyter notebook."""
     try:
         # See: https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
-        shell = get_ipython().__class__.__name__
+        shell = get_ipython().__class__.__name__    # type: ignore
         if shell == "ZMQInteractiveShell":
             return True  # Jupyter notebook or qtconsole
         elif shell == "TerminalInteractiveShell":

--- a/poetry.lock
+++ b/poetry.lock
@@ -3267,6 +3267,22 @@ objc = ["pyobjc-framework-Cocoa"]
 win32 = ["pywin32"]
 
 [[package]]
+name = "setuptools"
+version = "68.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3792,4 +3808,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "c46474691ca500c6a3a9c0cc0b6c1c1c3cfe3a370e92d47792b901df4f1a06b3"
+content-hash = "7441d452e217e6b794947846372ce680816c3575735dd589ce5f7da6578167b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ packages = [{include = "landingai"}]
 [tool.poetry.dependencies]  # main dependency group
 python = ">=3.8,<4.0"
 
-opencv-python = ">=4.5,<5.0"
+opencv-python = ">=4.5,<5.0"  # about 87MB (exclude transitive dependencies)
 numpy = ">=1.21.0,<2.0.0"
 pillow = "9.*" # Version 10.0.0 had a issue on FreeTypeFont that will be fixed on the next release 
 pydantic = { version = "1.*", extras = ["dotenv"] } # Version 2 has breaking changes (in particular to seetings)
 requests = "2.*"
-snowflake-connector-python = "3.0.*"
+snowflake-connector-python = "3.0.*"  # about 51MB (exclude transitive dependencies)
 bbox-visualizer = "^0.1.0"
 segmentation-mask-overlay = "^0.3.4"
 imageio = { version = "2.*", extras = ["ffmpeg"] }
@@ -47,6 +47,7 @@ testbook = "^0.4.2"
 types-aiofiles = "^23.1.0.4"
 types-tqdm = "^4.65.0.1"
 aioresponses = "^0.7.4"
+setuptools = "^68.0.0"
 
 
 [tool.poetry.group.examples.dependencies]

--- a/tests/data/responses/default_class_model_response.yaml
+++ b/tests/data/responses/default_class_model_response.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 200
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest

--- a/tests/data/responses/default_vp_model_response.yaml
+++ b/tests/data/responses/default_vp_model_response.yaml
@@ -25,4 +25,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 200
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=63035608-9d24-4342-8042-e4b08e084fde&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=63035608-9d24-4342-8042-e4b08e084fde&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_300.yaml
+++ b/tests/data/responses/v1_predict_status_300.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 300
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_400.yaml
+++ b/tests/data/responses/v1_predict_status_400.yaml
@@ -6,4 +6,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 400
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_401.yaml
+++ b/tests/data/responses/v1_predict_status_401.yaml
@@ -6,4 +6,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 401
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_403.yaml
+++ b/tests/data/responses/v1_predict_status_403.yaml
@@ -6,4 +6,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 403
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=dfa79692-75eb-4a48-b02e-b273751adbae&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=dfa79692-75eb-4a48-b02e-b273751adbae&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_404.yaml
+++ b/tests/data/responses/v1_predict_status_404.yaml
@@ -7,4 +7,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 404
-    url: https://predict.app.landing.ai/v0/foo?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib
+    url: https://predict.app.landing.ai/v0/foo?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_422.yaml
+++ b/tests/data/responses/v1_predict_status_422.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 422
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=12345&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=12345&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_429.yaml
+++ b/tests/data/responses/v1_predict_status_429.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 429
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_500.yaml
+++ b/tests/data/responses/v1_predict_status_500.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 500
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_503.yaml
+++ b/tests/data/responses/v1_predict_status_503.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 503
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest

--- a/tests/data/responses/v1_predict_status_504.yaml
+++ b/tests/data/responses/v1_predict_status_504.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 504
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest

--- a/tests/unit/landingai/test_predict.py
+++ b/tests/unit/landingai/test_predict.py
@@ -224,7 +224,7 @@ def test_predict_matching_expected_request_body():
         "file": ("image.png", _read_image_as_png_bytes(img_path), "image/png")
     }
     responses.post(
-        url="https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib",
+        url="https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest",
         match=[multipart_matcher(expected_request_files)],
         json={
             "backbonetype": None,

--- a/tests/unit/landingai/test_telemetry.py
+++ b/tests/unit/landingai/test_telemetry.py
@@ -1,0 +1,10 @@
+from landingai.telemetry import get_runtime_environment_info
+
+
+def test_get_environment_info():
+    info = get_runtime_environment_info()
+    assert info["lib_type"] == "pylib"
+    assert info["runtime"] == "pytest"
+    assert "lib_version" in info
+    assert "python_version" in info
+    assert "os" in info


### PR DESCRIPTION
Append lib version and runtime information as query params in the cloud inference reqeusts.
It helps us better understand how the lib is used and managing/deprecating code features.
 
**Extra context**: the “to-be-implemented” telemetry tracking mechanism (NATS message queue) can be opted out by the user. But this mechanism can’t be disabled by users. so it could still be useful to attach some minimum info to the inference requests that is always visible for us.