### PR TITLE
feat(postprocess): support rescale_bboxes()

### DIFF
--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -556,7 +556,9 @@ async def _upload_media(
         _LOGGER.warning(
             f"Skipping Media ({filename}, {filetype}) as it already exists in project ({project_id}), md5: {media_md5}, response: {resp_data}"
         )
-        raise DuplicateUploadError(f"Skipping Media ({filename}, {filetype}) as it already exists in project ({project_id}), md5: {media_md5}, response: {resp_data}")
+        raise DuplicateUploadError(
+            f"Skipping Media ({filename}, {filetype}) as it already exists in project ({project_id}), md5: {media_md5}, response: {resp_data}"
+        )
     elif "data" not in resp_data:
         raise HttpError(
             f"Failed to upload media due to HTTP {resp_data['code']} error, reason: {resp_data['message']}"

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -225,15 +225,14 @@ class Media:
             error_count = 0
             try:
                 resp = loop.run_until_complete(file_tasks)
-                if isinstance(resp, BaseException):
-                    error_count = 1
-                    medias_with_errors[filename] = resp
-                else:
-                    medias.append(resp)
+                medias.append(resp)
             except DuplicateUploadError:
                 if not tolerate_duplicate_upload:
                     raise
                 skipped_count = 1
+            except Exception:
+                error_count = 1
+                medias_with_errors[filename] = resp
 
         return {
             "num_uploaded": len(medias),

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -28,7 +28,7 @@ from landingai.data_management.utils import (
     obj_to_params,
     validate_metadata,
 )
-from landingai.exceptions import HttpError
+from landingai.exceptions import DuplicateUploadError, HttpError
 from landingai.utils import serialize_image
 
 MediaType = Enum("MediaType", ["image", "video"])
@@ -81,6 +81,7 @@ class Media:
         nothing_to_label: bool = False,
         metadata_dict: Optional[Dict[str, Any]] = None,
         validate_extensions: bool = True,
+        tolerate_duplicate_upload: bool = True,
     ) -> Dict[str, Any]:
         """
         Upload media to platform.
@@ -110,6 +111,9 @@ class Media:
             If set to False, will try to upload all files. Behavior of platform
              for unexpected extensions may not be correct - for example, most likely file
              will be uploaded to s3, but won't show in data browser.
+        tolerate_duplicate_upload: bool
+            Whether to tolerate duplicate upload. A duplicate upload is identified by status code 409. The server returns a 409 status code if the same media file content exists in the project.
+            Defaults to True. If set to False, will raise a `landingai.exceptions.HttpError` if it's a duplicate upload.
 
         Returns
         -------
@@ -179,6 +183,7 @@ class Media:
                 project_id,
                 validate_extensions,
                 skipped_count,
+                tolerate_duplicate_upload,
             )
             loop = asyncio.get_event_loop()
             (
@@ -217,13 +222,18 @@ class Media:
                 metadata,
             )
             loop = asyncio.get_event_loop()
-            resp = loop.run_until_complete(file_tasks)
             error_count = 0
-            if isinstance(resp, BaseException):
-                error_count = 1
-                medias_with_errors[filename] = resp
-            else:
-                medias.append(resp)
+            try:
+                resp = loop.run_until_complete(file_tasks)
+                if isinstance(resp, BaseException):
+                    error_count = 1
+                    medias_with_errors[filename] = resp
+                else:
+                    medias.append(resp)
+            except DuplicateUploadError:
+                if not tolerate_duplicate_upload:
+                    raise
+                skipped_count = 1
 
         return {
             "num_uploaded": len(medias),
@@ -434,6 +444,7 @@ async def _upload_folder(
     project_id: int,
     validate_extensions: bool,
     skipped_count: int,
+    tolerate_duplicate_upload: bool,
 ) -> Tuple[List[Any], int, int, Dict[str, Any]]:
     semaphore = asyncio.BoundedSemaphore(_CONCURRENCY_LIMIT)
     task_to_filename = {}
@@ -467,6 +478,10 @@ async def _upload_folder(
     for resp in tqdm(asyncio.as_completed(tasks), total=len(tasks)):
         try:
             await resp
+        except DuplicateUploadError:
+            if not tolerate_duplicate_upload:
+                raise
+            skipped_count += 1
         except Exception:
             error_count += 1
 
@@ -487,7 +502,14 @@ async def _upload_media_with_semaphore(
     semaphore: asyncio.BoundedSemaphore,
 ) -> Dict[str, Any]:
     async with semaphore:
-        return await _upload_media(client, dataset_id, filename, path, project_id, ext)
+        return await _upload_media(
+            client,
+            dataset_id,
+            filename,
+            path,
+            project_id,
+            ext,
+        )
 
 
 async def _upload_media(
@@ -530,7 +552,12 @@ async def _upload_media(
             "uploadId": dataset_id,
         },
     )
-    if "data" not in resp_data:
+    if resp_data["code"] == 409:
+        _LOGGER.warning(
+            f"Skipping Media ({filename}, {filetype}) as it already exists in project ({project_id}), md5: {media_md5}, response: {resp_data}"
+        )
+        raise DuplicateUploadError(f"Skipping Media ({filename}, {filetype}) as it already exists in project ({project_id}), md5: {media_md5}, response: {resp_data}")
+    elif "data" not in resp_data:
         raise HttpError(
             f"Failed to upload media due to HTTP {resp_data['code']} error, reason: {resp_data['message']}"
         )

--- a/landingai/exceptions.py
+++ b/landingai/exceptions.py
@@ -110,6 +110,17 @@ class HttpError(Exception):
         return self.message
 
 
+class DuplicateUploadError(Exception):
+    """Exception raised when the uploaded media is already exists in the project. Status code: 409."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class UnexpectedRedirectError(Exception):
     """Exception raised when the client encounters an unexpected redirect. Status code: 3xx."""
 

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -15,6 +15,31 @@ from landingai.common import (
 )
 
 
+def rescale_bboxes_by_image_size(
+    predictions: Sequence[ObjectDetectionPrediction],
+    from_image: Image,
+    to_image: Image,
+) -> Sequence[ObjectDetectionPrediction]:
+    """Rescale the bounding boxes of each ObjectDetectionPrediction in a list based on the size of the reference images.
+    NOTE: this operation is NOT in-place. The input predictions will remain the same.
+
+    Parameters
+    ----------
+    predictions: a list of ObjectDetectionPrediction to be rescaled.
+    from_image: the image that serves the denominator of the scale factor. The input bboxes is at the same scale of this image.
+    to_image: the image that serves the numerator of the scale factor. The ouput bboxes will be at the same scale of this image.
+
+    Returns
+    -------
+    A list of ObjectDetectionPrediction where the bboxes has been rescaled.
+    """
+    scale_factor = (
+        to_image.size[1] / from_image.size[1],
+        to_image.size[0] / from_image.size[0],
+    )
+    return rescale_bboxes(predictions, scale_factor)
+
+
 def rescale_bboxes(
     predictions: Sequence[ObjectDetectionPrediction],
     scale_factor: Union[Tuple[float, float], float],

--- a/landingai/postprocess.py
+++ b/landingai/postprocess.py
@@ -15,6 +15,43 @@ from landingai.common import (
 )
 
 
+def rescale_bboxes(
+    predictions: Sequence[ObjectDetectionPrediction],
+    scale_factor: Union[Tuple[float, float], float],
+) -> Sequence[ObjectDetectionPrediction]:
+    """Rescale the bounding boxes of each ObjectDetectionPrediction in a list based on the scale factor.
+    NOTE: this operation is NOT in-place. The input predictions will remain the same.
+
+    Parameters
+    ----------
+    predictions: a list of ObjectDetectionPrediction to be rescaled.
+    scale_factor: the scale factor that will be applied to the predictions. The scale factors are (height, width) if it's a tuple.
+
+    Returns
+    -------
+    A list of ObjectDetectionPrediction where the bboxes has been rescaled.
+    """
+    if isinstance(scale_factor, float):
+        scale_factor = (scale_factor, scale_factor)
+    assert scale_factor[0] > 0 and scale_factor[1] > 0, "Scale factor must be > 0"
+    height_scale, width_scale = scale_factor
+    return [
+        ObjectDetectionPrediction(
+            id=pred.id,
+            score=pred.score,
+            label_index=pred.label_index,
+            label_name=pred.label_name,
+            bboxes=(
+                math.floor(pred.bboxes[0] * width_scale),  # xmin
+                math.floor(pred.bboxes[1] * height_scale),  # ymin
+                math.ceil(pred.bboxes[2] * width_scale),  # xmax
+                math.ceil(pred.bboxes[3] * height_scale),  # ymax
+            ),
+        )
+        for pred in predictions
+    ]
+
+
 def crop(
     predictions: Sequence[Prediction], image: Union[np.ndarray, Image]
 ) -> Sequence[Image]:

--- a/tests/unit/landingai/test_postprocess.py
+++ b/tests/unit/landingai/test_postprocess.py
@@ -7,6 +7,7 @@ from landingai.common import ClassificationPrediction, ObjectDetectionPrediction
 from landingai.postprocess import (
     crop,
     rescale_bboxes,
+    rescale_bboxes_by_image_size,
     segmentation_class_pixel_coverage,
 )
 from landingai.predict import Predictor
@@ -29,6 +30,36 @@ def test_segmentation_class_pixel_coverage():
     assert coverage[4] == (0.24161325195570196, "Brown Field")
     assert coverage[5] == (0.40297209139620843, "Trees")
     assert coverage[6] == (0.340975356067672, "Structure")
+
+
+def test_rescale_bboxes_by_image_size():
+    input = [
+        ObjectDetectionPrediction(
+            id="123",
+            score=0.1,
+            label_index=1,
+            label_name="class1",
+            bboxes=(4, 10, 22, 23),
+        ),
+        ObjectDetectionPrediction(
+            id="124",
+            score=0.1,
+            label_index=1,
+            label_name="class2",
+            bboxes=(0, 0, 17, 33),
+        ),
+    ]
+    raw_image = Image.new("RGB", (100, 200))
+    resized_image = raw_image.resize((20, 60))
+    result = rescale_bboxes_by_image_size(input, raw_image, resized_image)
+    assert result[0].bboxes == (0, 3, 5, 7)
+    assert result[1].bboxes == (0, 0, 4, 10)
+
+    raw_image = Image.new("RGB", (150, 300))
+    resized_image = raw_image.resize((100, 200))
+    result = rescale_bboxes_by_image_size(input, resized_image, raw_image)
+    assert result[0].bboxes == (6, 15, 33, 35)
+    assert result[1].bboxes == (0, 0, 26, 50)
 
 
 def test_rescale_bboxes():

--- a/tests/unit/landingai/test_postprocess.py
+++ b/tests/unit/landingai/test_postprocess.py
@@ -4,7 +4,11 @@ import responses
 from PIL import Image
 
 from landingai.common import ClassificationPrediction, ObjectDetectionPrediction
-from landingai.postprocess import crop, segmentation_class_pixel_coverage
+from landingai.postprocess import (
+    crop,
+    rescale_bboxes,
+    segmentation_class_pixel_coverage,
+)
 from landingai.predict import Predictor
 
 
@@ -25,6 +29,32 @@ def test_segmentation_class_pixel_coverage():
     assert coverage[4] == (0.24161325195570196, "Brown Field")
     assert coverage[5] == (0.40297209139620843, "Trees")
     assert coverage[6] == (0.340975356067672, "Structure")
+
+
+def test_rescale_bboxes():
+    input = [
+        ObjectDetectionPrediction(
+            id="123",
+            score=0.1,
+            label_index=1,
+            label_name="class1",
+            bboxes=(4, 10, 22, 23),
+        ),
+        ObjectDetectionPrediction(
+            id="124",
+            score=0.1,
+            label_index=1,
+            label_name="class2",
+            bboxes=(0, 0, 17, 33),
+        ),
+    ]
+    result = rescale_bboxes(input, (0.3, 0.2))
+    assert result[0].bboxes == (0, 3, 5, 7)
+    assert result[1].bboxes == (0, 0, 4, 10)
+
+    result = rescale_bboxes(input, 1.5)
+    assert result[0].bboxes == (6, 15, 33, 35)
+    assert result[1].bboxes == (0, 0, 26, 50)
 
 
 def test_crop():


### PR DESCRIPTION
**New feature in `postprocess`**

1. Add a new post-processing function `rescale_bboxes()` and `rescale_bboxes_by_image_size()`.

**Motivation**

When dealing with large images, we often need to rescale the original image to a smaller size for training and inference. And we need to scale the prediction result back when we need to use it on the original image.
This is a follow-up to https://github.com/landing-ai/landingai-python/pull/76

**Improvements to media upload**
1. Introduce a `tolerate_duplicate_upload` flag to improve the usability of media upload API. Now it tolerates the 409 status code and log a warning by default instead of throwing exceptions.
2. Improve media upload error handling logic: catch the exception properly

