### PR TITLE
feat(timer): introudce a timer module to better track latency

### DIFF
--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -685,7 +685,7 @@ def _create_session(url: str, num_retry: int, headers: Dict[str, str]) -> Sessio
     return session
 
 
-@Timer(name="do_inference")
+@Timer(name="_do_inference", log_fn=_LOGGER.debug)
 def _do_inference(
     session: Session,
     endpoint_url: str,

--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -21,6 +21,7 @@ from landingai.common import (
 )
 from landingai.exceptions import HttpResponse
 from landingai.telemetry import get_runtime_environment_info, is_running_in_pytest
+from landingai.timer import Timer
 from landingai.utils import load_api_credential, serialize_image
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ class Predictor:
         }
         return headers
 
+    @Timer(name="Predictor.predict")
     def predict(
         self, image: Union[np.ndarray, PIL.Image.Image], **kwargs: Any
     ) -> List[Prediction]:
@@ -120,6 +122,7 @@ class OcrPredictor(Predictor):
         headers = self._build_default_headers(self._api_credential)
         self._session = _create_session(Predictor._url, self._num_retry, headers)
 
+    @Timer(name="OcrPredictor.predict")
     def predict(
         self, image: Union[np.ndarray, PIL.Image.Image], **kwargs: Any
     ) -> List[Prediction]:
@@ -198,6 +201,7 @@ class EdgePredictor(Predictor):
             self._url, self._num_retry, {"contentType": "multipart/form-data"}
         )
 
+    @Timer(name="EdgePredictor.predict")
     def predict(
         self, image: Union[np.ndarray, PIL.Image.Image], **kwargs: Any
     ) -> List[Prediction]:
@@ -681,6 +685,7 @@ def _create_session(url: str, num_retry: int, headers: Dict[str, str]) -> Sessio
     return session
 
 
+@Timer(name="do_inference")
 def _do_inference(
     session: Session,
     endpoint_url: str,

--- a/landingai/timer.py
+++ b/landingai/timer.py
@@ -1,0 +1,183 @@
+"""Timer class for timing code execution and reporting results."""
+
+import logging
+import math
+import pprint
+import statistics
+import time
+from collections import defaultdict, deque
+from contextlib import ContextDecorator
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import partial
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Sequence
+
+
+class TextColor(Enum):
+    GRAY = "\x1b[38;21m"
+    BLUE = "\x1b[38;5;39m"
+    YELLOW = "\x1b[38;5;226m"
+    RED = "\x1b[38;5;196m"
+    BOLD_RED = "\x1b[31;1m"
+    RESET = "\x1b[0m"
+
+
+_MAX_SIZE = 10_000
+
+
+class TimerStats:
+    """Custom dictionary that stores time values of different timers.
+    For each timer, it stores a sequence of time duration values. Each sequence is limited to a maximum size to avoid memory issues.
+
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Add a private dictionary keeping track of all timings"""
+        super().__init__(*args, **kwargs)
+        self._timings: Dict[str, Sequence[float]] = defaultdict(
+            partial(deque, maxlen=_MAX_SIZE)
+        )
+
+    def add(self, name: str, value: float) -> None:
+        """Add a timing value to the given timer."""
+        self._timings[name].append(value)
+
+    def clear(self) -> None:
+        """Clear timers."""
+        self._timings.clear()
+
+    def apply(self, func: Callable[[List[float]], float], name: str) -> float:
+        """Apply a function to the results of one named timer."""
+        if name in self._timings:
+            return func(self._timings[name])
+        raise KeyError(name)
+
+    def count(self, name: str) -> float:
+        """Number of timings."""
+        return self.apply(len, name=name)
+
+    def total(self, name: str) -> float:
+        """Total time for timers."""
+        return self.apply(sum, name=name)
+
+    def min(self, name: str) -> float:
+        """Minimal value of timings."""
+        return self.apply(lambda values: min(values or [0]), name=name)
+
+    def max(self, name: str) -> float:
+        """Maximal value of timings."""
+        return self.apply(lambda values: max(values or [0]), name=name)
+
+    def mean(self, name: str) -> float:
+        """Mean value of timings."""
+        return self.apply(lambda values: statistics.mean(values or [0]), name=name)
+
+    def median(self, name: str) -> float:
+        """Median value of timings."""
+        return self.apply(lambda values: statistics.median(values or [0]), name=name)
+
+    def stdev(self, name: str) -> float:
+        """Standard deviation of timings."""
+        if name in self._timings:
+            value = self._timings[name]
+            return statistics.stdev(value) if len(value) >= 2 else math.nan
+        raise KeyError(name)
+
+    def stats(self, name: str) -> Dict[str, float]:
+        """All the stats for a given timer."""
+        return {
+            "count": self.count(name),
+            "min": self.min(name),
+            "max": self.max(name),
+            "mean": self.mean(name),
+            "median": self.median(name),
+            "stdev": self.stdev(name),
+            "sum_total": self.total(name),
+        }
+
+    def __repr__(self) -> str:
+        """Return a string representation of the TimerStats."""
+        stats_repr = {k: self.stats(k) for k in self._timings.keys()}
+        return f"{self.__class__.__name__}({pprint.pformat(stats_repr)})"
+
+
+@dataclass
+class Timer(ContextDecorator):
+    """Time your code using a class, context manager, or decorator.
+    See below examples for usage.
+    As a class:
+    ```
+    t = Timer(name="class")
+    t.start()
+    # Do something
+    t.stop()
+    ```
+
+    As a context manager:
+    ```
+    with Timer(name="context manager"):
+        # Do something
+    ```
+
+    As a decorator:
+    ```
+    @Timer(name="decorator")
+    def stuff():
+        # Do something
+    ```
+
+    All the time values are stored in a global dictionary, accessible via the `stats` attribute.
+    See the `TimerStats` class for more information.
+    """
+
+    # Global stats of all the timers
+    stats: ClassVar[TimerStats] = TimerStats()
+    # Instance attributes
+    name: str = "default"
+    text: str = (
+        "Timer '{name}' finished. Elapsed time: {color}{:0.3f}{color_reset} seconds."
+    )
+    log_fn: Callable[[str], None] = logging.getLogger(__name__).info
+    _elapsed_time: float = field(default=math.nan, init=False, repr=False)
+    _start_time: Optional[float] = field(default=None, init=False, repr=False)
+
+    def start(self) -> None:
+        """Start a new timer."""
+        if self._start_time is not None:
+            raise ValueError("Timer is running. Use .stop() to stop it")
+
+        self._start_time = time.perf_counter()
+
+    def stop(self) -> float:
+        """Stop the timer, and report the elapsed time."""
+        if self._start_time is None:
+            raise ValueError("Timer is not running. Use .start() to start it")
+
+        # Calculate elapsed time
+        self._elapsed_time = time.perf_counter() - self._start_time
+
+        # Report elapsed time
+        attributes = {
+            "name": self.name,
+            "milliseconds": self._elapsed_time * 1000,
+            "seconds": self._elapsed_time,
+            "minutes": self._elapsed_time / 60,
+            "color": TextColor.BOLD_RED.value,
+            "color_reset": TextColor.RESET.value,
+        }
+        text = self.text.format(self._elapsed_time, **attributes)
+        self.log_fn(str(text))
+        # Save stats
+        Timer.stats.add(self.name, self._elapsed_time)
+
+        self._start_time = None
+        return self._elapsed_time
+
+    def __enter__(self) -> "Timer":
+        """Start a new timer as a context manager."""
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        """Stop the context manager timer."""
+        self.stop()

--- a/landingai/timer.py
+++ b/landingai/timer.py
@@ -10,7 +10,7 @@ from contextlib import ContextDecorator
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Sequence
+from typing import Any, Callable, ClassVar, Dict, MutableSequence, Optional, Sequence
 
 
 class TextColor(Enum):
@@ -34,8 +34,8 @@ class TimerStats:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Add a private dictionary keeping track of all timings"""
         super().__init__(*args, **kwargs)
-        self._timings: Dict[str, Sequence[float]] = defaultdict(
-            partial(deque, maxlen=_MAX_SIZE)
+        self._timings: Dict[str, MutableSequence[float]] = defaultdict(
+            partial(deque, maxlen=_MAX_SIZE)  # type: ignore
         )
 
     def add(self, name: str, value: float) -> None:
@@ -46,7 +46,7 @@ class TimerStats:
         """Clear timers."""
         self._timings.clear()
 
-    def apply(self, func: Callable[[List[float]], float], name: str) -> float:
+    def apply(self, func: Callable[[Sequence[float]], float], name: str) -> float:
         """Apply a function to the results of one named timer."""
         if name in self._timings:
             return func(self._timings[name])

--- a/tests/unit/landingai/test_timer.py
+++ b/tests/unit/landingai/test_timer.py
@@ -29,15 +29,13 @@ def test_timer(caplog):
 
 
 def test_timer_get_global_stats():
-    timer_keys = ["1", "2", "3"]
+    timer_keys = ["1", "2"]
     for k in timer_keys:
         for _ in range(2 * int(k)):
             with Timer(name=k):
-                time.sleep(0.1 * int(k))
+                time.sleep(0.2 * int(k))
 
     for k in timer_keys:
         actual = Timer.stats.stats(k)
         assert actual["count"] == int(k) * 2
-        assert actual["min"] == pytest.approx(0.1 * int(k), abs=0.05)
-        assert actual["max"] == pytest.approx(0.1 * int(k), abs=0.05)
-        assert actual["sum_total"] >= 0.1 * int(k)
+        assert actual["sum_total"] >= 0.2 * int(k)

--- a/tests/unit/landingai/test_timer.py
+++ b/tests/unit/landingai/test_timer.py
@@ -1,7 +1,5 @@
 import time
 
-import pytest
-
 from landingai.timer import Timer
 
 

--- a/tests/unit/landingai/test_timer.py
+++ b/tests/unit/landingai/test_timer.py
@@ -1,0 +1,43 @@
+import time
+
+import pytest
+
+from landingai.timer import Timer
+
+
+def test_timer(caplog):
+    t = Timer(name="manual")
+    t.start()
+    time.sleep(0.1)
+    t.stop()
+    assert "Timer 'manual' finished. Elapsed time:" in caplog.text
+
+    with Timer(name="context manager"):
+        time.sleep(0.2)
+    assert "Timer 'context manager' finished. Elapsed time:" in caplog.text
+
+    @Timer(name="decorator")
+    def do_stuff():
+        time.sleep(0.3)
+
+    do_stuff()
+    assert "Timer 'decorator' finished. Elapsed time:" in caplog.text
+
+    with Timer():
+        time.sleep(0.2)
+    assert "Timer 'default' finished. Elapsed time:" in caplog.text
+
+
+def test_timer_get_global_stats():
+    timer_keys = ["1", "2", "3"]
+    for k in timer_keys:
+        for _ in range(2 * int(k)):
+            with Timer(name=k):
+                time.sleep(0.01 * int(k))
+
+    for k in timer_keys:
+        actual = Timer.stats.stats(k)
+        assert actual["count"] == int(k) * 2
+        assert actual["min"] == pytest.approx(0.01 * int(k), abs=0.01)
+        assert actual["max"] == pytest.approx(0.01 * int(k), abs=0.01)
+        assert actual["sum_total"] >= 0.01 * int(k)

--- a/tests/unit/landingai/test_timer.py
+++ b/tests/unit/landingai/test_timer.py
@@ -33,11 +33,11 @@ def test_timer_get_global_stats():
     for k in timer_keys:
         for _ in range(2 * int(k)):
             with Timer(name=k):
-                time.sleep(0.01 * int(k))
+                time.sleep(0.1 * int(k))
 
     for k in timer_keys:
         actual = Timer.stats.stats(k)
         assert actual["count"] == int(k) * 2
-        assert actual["min"] == pytest.approx(0.01 * int(k), abs=0.01)
-        assert actual["max"] == pytest.approx(0.01 * int(k), abs=0.01)
-        assert actual["sum_total"] >= 0.01 * int(k)
+        assert actual["min"] == pytest.approx(0.1 * int(k), abs=0.05)
+        assert actual["max"] == pytest.approx(0.1 * int(k), abs=0.05)
+        assert actual["sum_total"] >= 0.1 * int(k)


### PR DESCRIPTION
Introudce a timer module to better track latency and make micro-benchmark easier

See below examples for usage.

**As a class**
```
t = Timer(name="class")
t.start()
# Do something
t.stop()
```

**As a context manager**
```
with Timer(name="context manager"):
    # Do something
```

**As a decorator**
```
@Timer(name="decorator")
def stuff():
    # Do something
```