### PR TITLE
fix(ocr): remove the maximum pixel limit in the ocr app

### DIFF
--- a/examples/apps/ocr/app.py
+++ b/examples/apps/ocr/app.py
@@ -24,6 +24,7 @@ setup_page(page_title="LandingLens OCR")
 
 Image.MAX_IMAGE_PIXELS = None
 
+
 class DetModel(str, Enum):
     AUTO_DETECT = "multi-text"
     MANUAL_ROI = "single-text"

--- a/examples/apps/ocr/app.py
+++ b/examples/apps/ocr/app.py
@@ -22,6 +22,7 @@ from landingai.visualize import overlay_predictions
 
 setup_page(page_title="LandingLens OCR")
 
+Image.MAX_IMAGE_PIXELS = None
 
 class DetModel(str, Enum):
     AUTO_DETECT = "multi-text"


### PR DESCRIPTION
remove the maximum pixel limit in the ocr app.
our customers have large images to test against the ocr app.