### PR TITLE
Turn off check connectivity by default

### DIFF
--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -40,7 +40,7 @@ class Predictor:
         endpoint_id: str,
         *,
         api_key: Optional[str] = None,
-        check_server_ready: bool = True,
+        check_server_ready: bool = False,
     ) -> None:
         """Predictor constructor
 
@@ -224,7 +224,10 @@ class EdgePredictor(Predictor):
     """`EdgePredictor` runs local inference by connecting to an edge inference service (e.g. LandingEdge)"""
 
     def __init__(
-        self, host: str = "localhost", port: int = 8000, check_server_ready: bool = True
+        self,
+        host: str = "localhost",
+        port: int = 8000,
+        check_server_ready: bool = False,
     ) -> None:
         """By default the inference service runs on `localhost:8000`
 

--- a/tests/unit/landingai/test_predict.py
+++ b/tests/unit/landingai/test_predict.py
@@ -273,7 +273,13 @@ def test_edge_class_predict(connect_mock):
 @responses.activate
 def test_connection_check():
     with pytest.raises(ConnectionError):
-        EdgePredictor("localhost", 51203)  # Non existing port
+        EdgePredictor("localhost", 51203, check_server_ready=True)  # Non existing port
+    # There should not be any ConnectionError for Cloud inference endpoint
+    Predictor(
+        endpoint_id="123",
+        api_key="land_sk_1234",
+        check_server_ready=True,
+    )
 
 
 @responses.activate


### PR DESCRIPTION
Check connectivity code doesn't work well with colab.
Turning it off for now to avoid breaking colab examples.