### PR TITLE
Switch OCR endpoint to prod

### DIFF
--- a/examples/license-plate-ocr-notebook/license_plate_ocr.ipynb
+++ b/examples/license-plate-ocr-notebook/license_plate_ocr.ipynb
@@ -95,9 +95,9 @@
    },
    "outputs": [],
    "source": [
-    "from landingai.postprocess import crop\n",
     "from landingai.predict import Predictor\n",
     "from landingai import visualize\n",
+    "\n",
     "\n",
     "def detect_license_plates(frames):\n",
     "    bounding_boxes = []\n",
@@ -160,18 +160,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## WARNING - BELOW CODE DOES NOT WORK\n",
-    "\n",
-    "Below code cells do not work since the OCR endpoint is not publicly available yet.\n",
-    "Please stay tuned, we are working on making it publicly available soon.\n",
-    "\n",
-    "We made the below code available early just to demonstrate how to chain two different models together with our Python SDK."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "<a name=\"ocr-and-data-retrieval\"></a>\n",
     "\n",
     "## OCR and Data Retrieval\n",
@@ -187,7 +175,6 @@
    "outputs": [],
    "source": [
     "from landingai.predict import OcrPredictor\n",
-    "import PIL.Image\n",
     "\n",
     "# TODO: set your OCR API key \n",
     "API_KEY = \"\"\n",

--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -152,7 +152,7 @@ class Predictor:
 class OcrPredictor(Predictor):
     """A class that calls your OCR inference endpoint on the LandingLens platform."""
 
-    _url: str = "https://app.staging.landing.ai/ocr/v1/detect-text"
+    _url: str = "https://app.landing.ai/ocr/v1/detect-text"
 
     def __init__(
         self,

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -146,14 +146,9 @@ def test_class_predict():
     img_with_masks.save("tests/output/test_class.jpg")
 
 
-# TODO: re-enable below test after OCR endpoint is deployed to prod
-@pytest.mark.skip(reason="OCR endpoint is not deployed to prod yet")
 def test_ocr_predict():
     Path("tests/output").mkdir(parents=True, exist_ok=True)
-    predictor = OcrPredictor(
-        # TODO: replace with a prod key after the OCR endpoint is deployed to prod
-        api_key="",
-    )
+    predictor = OcrPredictor(api_key=_API_KEY)
     img = Image.open("tests/data/images/ocr_test.png")
     assert img is not None
     # Test multi line

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -204,13 +204,13 @@ def test_ocr_predict():
     expected = [
         {
             "text": "公司名称",
-            "location": [(98, 20), (367, 20), (367, 77), (98, 77)],
-            "score": 0.9093,
+            "location": [(99, 19), (366, 19), (366, 75), (99, 75)],
+            "score": 0.828,
         },
         {
             "text": "英语学习",
-            "location": [(597, 842), (814, 845), (814, 894), (597, 892)],
-            "score": 0.9029,
+            "location": [(599, 842), (814, 845), (814, 894), (599, 892)],
+            "score": 0.9393,
         },
     ]
     for pred, expected in zip(preds, expected):

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -204,18 +204,18 @@ def test_ocr_predict():
     expected = [
         {
             "text": "公司名称",
-            "location": [(99, 19), (366, 19), (366, 75), (99, 75)],
-            "score": 0.8279303908348083,
+            "location": [(98, 20), (367, 20), (367, 77), (98, 77)],
+            "score": 0.9093,
         },
         {
             "text": "英语学习",
-            "location": [(599, 842), (814, 845), (814, 894), (599, 892)],
-            "score": 0.939440906047821,
+            "location": [(597, 842), (814, 845), (814, 894), (597, 892)],
+            "score": 0.9029,
         },
     ]
     for pred, expected in zip(preds, expected):
         assert pred.text == expected["text"]
         assert pred.location == expected["location"]
-        assert pred.score == expected["score"]
+        assert pytest.approx(pred.score, 0.0001) == expected["score"]
     img_with_masks = overlay_predictions(preds, img)
     img_with_masks.save("tests/output/test_ocr_singleline.jpg")


### PR DESCRIPTION
1. Update OCRPredictor to use the prod endpoint
2. Update the license-plate-ocr notebook