### PR TITLE
Avoiding Firefox warnings on GA config

### DIFF
--- a/docs/templates/module.html.jinja2
+++ b/docs/templates/module.html.jinja2
@@ -11,6 +11,6 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'G-6Z0XHQRFQQ');
+    gtag('config', 'G-6Z0XHQRFQQ', {cookie_domain: 'landing-ai.github.io', cookie_flags: 'SameSite=None;Secure'});
     </script>
 {% endblock %}


### PR DESCRIPTION
Firefox complains about the broad cookie settings when configuring GA. This PR fixes that.