### PR TITLE
Deprecate the use of __del__ in image sources

### DIFF
--- a/docs/user_guide/4_pipelines.md
+++ b/docs/user_guide/4_pipelines.md
@@ -15,7 +15,7 @@ You can use data pipelines to run predictions quite easily, using the `landingai
 predictor = Predictor(endpoint_id="abcde-1234-xxxx", api_key="land_sk_xxxx")
 
 # Get images from Webcam at a 1 FPS rate, run predictions on it and save results.
-with webcam as Webcam(fps=1):
+with Webcam(fps=1) as webcam:
     for frame in webcam:
         frame
             .downsize(width=512)
@@ -29,7 +29,7 @@ You can also check the prediction result using some of the helper methods:
 predictor = Predictor(endpoint_id="abcde-1234-xxxx", api_key="land_sk_xxxx")
 # Get images from Webcam at a 1 FPS rate, run predictions on it and check if
 # in the prediction we find "coffee-mug", a class created in LandingLens platform:
-with webcam as Webcam(fps=1):
+with Webcam(fps=1) as webcam:
     for frame in webcam:
         frame = frame
             .downsize(width=512)

--- a/docs/user_guide/4_pipelines.md
+++ b/docs/user_guide/4_pipelines.md
@@ -15,11 +15,12 @@ You can use data pipelines to run predictions quite easily, using the `landingai
 predictor = Predictor(endpoint_id="abcde-1234-xxxx", api_key="land_sk_xxxx")
 
 # Get images from Webcam at a 1 FPS rate, run predictions on it and save results.
-for frame in Webcam(fps=1):
-    frame
-        .downsize(width=512)
-        .run_predict(predictor=predictor)
-        .save_image(f"/tmp/detected-object", image_src="overlay")
+with webcam as Webcam(fps=1):
+    for frame in webcam:
+        frame
+            .downsize(width=512)
+            .run_predict(predictor=predictor)
+            .save_image(f"/tmp/detected-object", image_src="overlay")
 ```
 
 You can also check the prediction result using some of the helper methods:
@@ -28,12 +29,13 @@ You can also check the prediction result using some of the helper methods:
 predictor = Predictor(endpoint_id="abcde-1234-xxxx", api_key="land_sk_xxxx")
 # Get images from Webcam at a 1 FPS rate, run predictions on it and check if
 # in the prediction we find "coffee-mug", a class created in LandingLens platform:
-for frame in Webcam(fps=1):
-    frame = frame
-        .downsize(width=512)
-        .run_predict(predictor=predictor)
-    if "coffee-mug" in frame.predictions:
-        print(f"Found {len(frame.predictions)} coffee mugs in the image")
+with webcam as Webcam(fps=1):
+    for frame in webcam:
+        frame = frame
+            .downsize(width=512)
+            .run_predict(predictor=predictor)
+        if "coffee-mug" in frame.predictions:
+            print(f"Found {len(frame.predictions)} coffee mugs in the image")
 ```
 
 FrameSet predictions has also other methods to help filter predicted classes:

--- a/landingai/pipeline/image_source.py
+++ b/landingai/pipeline/image_source.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Type
+from typing import Any, Literal, Type
 from typing import Iterator as IteratorType
 from typing import List, Optional, Union, Tuple
 import warnings
@@ -40,7 +40,7 @@ class ImageSourceBase(Iterator):
     def __next__(self) -> FrameSet:
         raise NotImplementedError()
 
-    def __enter__(self):
+    def __enter__(self) -> "ImageSourceBase":
         return self
 
     def __exit__(
@@ -48,8 +48,9 @@ class ImageSourceBase(Iterator):
         exc_type: Optional[Type[BaseException]],
         exc: Optional[BaseException],
         traceback: Optional[TracebackType],
-    ) -> Optional[bool]:
+    ) -> Literal[False]:
         self.close()
+        return False
 
 
 class ImageFolder(ImageSourceBase):
@@ -229,7 +230,7 @@ class VideoFile(ImageSourceBase):
 
 # openCV's default VideoCapture cannot drop frames so if the CPU is overloaded the stream will start to lag behind realtime.
 # This class creates a treaded capture implementation that can stay up to date wit the stream and decodes frames only on demand
-class NetworkedCamera(ImageSourceBase, BaseModel):
+class NetworkedCamera(BaseModel, ImageSourceBase):
     """The NetworkCamera class can connect to RTSP and other live video sources in order to grab frames. The main concern is to be able to consume frames at the source speed and drop them as needed to ensure the application allday gets the lastes frame"""
 
     stream_url: str

--- a/landingai/pipeline/image_source.py
+++ b/landingai/pipeline/image_source.py
@@ -219,8 +219,7 @@ class VideoFile(ImageSourceBase):
         if os.path.exists(self._local_cache_dir):
             # TODO: deprecate the __del__ method in future versions.
             warnings.warn(
-                "VideoFile object should be closed explicitly with close(), or using with statement."
-                "Automatically closing it "
+                "VideoFile object should be closed explicitly with close(), or using 'with' statement."
             )
             self.close()
 
@@ -295,7 +294,6 @@ class NetworkedCamera(ImageSourceBase, BaseModel):
             # TODO: deprecate the __del__ method in future versions.
             warnings.warn(
                 "NetworkedCamera object should be closed explicitly with close(), or using with statement."
-                "Automatically closing it when derreferencing is deprecated, and will be removed in future versions."
             )
             self.close()
 

--- a/landingai/pipeline/image_source.py
+++ b/landingai/pipeline/image_source.py
@@ -364,6 +364,10 @@ class NetworkedCamera(BaseModel, ImageSourceBase):
             return True
         return False
 
+    # Make the class iterable. TODO Needs test cases
+    def __iter__(self) -> Any:
+        return self
+
     def __next__(self) -> "FrameSet":
         return self.get_latest_frame()
 

--- a/tests/unit/landingai/pipeline/test_image_source.py
+++ b/tests/unit/landingai/pipeline/test_image_source.py
@@ -105,7 +105,6 @@ def test_networked_camera():
     with NetworkedCamera(
         stream_url=test_video_file_path, motion_detection_threshold=50
     ) as camera:
-
         # Get the first frame and the next frame where motion is detected. I keep the detection threshold low to make the test fast
         i = iter(camera)
         frame1 = next(i)
@@ -117,7 +116,9 @@ def test_networked_camera():
         # frame1.show_image()
         # frame2.show_image()
         image_distance = np.sum(
-            cv2.absdiff(src1=frame1[0].to_numpy_array(), src2=frame2[0].to_numpy_array())
+            cv2.absdiff(
+                src1=frame1[0].to_numpy_array(), src2=frame2[0].to_numpy_array()
+            )
         )
 
         # Compute the diff by summing the delta between each pixel across the two images

--- a/tests/unit/landingai/pipeline/test_image_source.py
+++ b/tests/unit/landingai/pipeline/test_image_source.py
@@ -22,35 +22,35 @@ def test_image_folder_for_loop(input_image_folder):
     p = input_image_folder.glob("*")
     expected_files = [str(x) for x in p if x.is_file()]
     expected_files.sort()
-    folder = ImageFolder(input_image_folder)
-    assert len(list(folder)) == 8
-    for i, frames in enumerate(folder):
-        assert isinstance(frames, FrameSet)
-        assert frames[0].image.size == (20, 20)
-        assert frames[0].metadata["image_path"] == expected_files[i]
-    assert len(list(folder)) == 8
+    with ImageFolder(input_image_folder) as folder:
+        assert len(list(folder)) == 8
+        for i, frames in enumerate(folder):
+            assert isinstance(frames, FrameSet)
+            assert frames[0].image.size == (20, 20)
+            assert frames[0].metadata["image_path"] == expected_files[i]
+        assert len(list(folder)) == 8
 
 
 def test_image_folder_with_input_files(input_image_files):
-    folder = ImageFolder(input_image_files)
-    assert len(list(folder)) == 8
-    for i, frames in enumerate(folder):
-        assert isinstance(frames, FrameSet)
-        assert frames[0].image.size == (20, 20)
-        assert frames[0].metadata["image_path"] == input_image_files[i]
+    with ImageFolder(input_image_files) as folder:
+        assert len(list(folder)) == 8
+        for i, frames in enumerate(folder):
+            assert isinstance(frames, FrameSet)
+            assert frames[0].image.size == (20, 20)
+            assert frames[0].metadata["image_path"] == input_image_files[i]
 
 
 def test_image_folder_with_glob_patterns(input_image_folder):
-    folder = input_image_folder
-    jpg_cnt = 2 if os.name == "nt" else 1
-    # Test __len__
-    assert len(ImageFolder(glob_pattern=[str(folder / "*.jpg")])) == jpg_cnt
-    assert len(ImageFolder(glob_pattern=str(folder / "*.bmp"))) == 1
-    # Test __iter__
-    assert len(list(ImageFolder(glob_pattern=[str(folder / "*.jpg")]))) == jpg_cnt
-    assert len(list(ImageFolder(str(folder)))) == 8
-    # Test glob pattern on nested files
-    assert len(ImageFolder(glob_pattern=str(folder / "**/*.png"))) == 4
+    with input_image_folder as folder:
+        jpg_cnt = 2 if os.name == "nt" else 1
+        # Test __len__
+        assert len(ImageFolder(glob_pattern=[str(folder / "*.jpg")])) == jpg_cnt
+        assert len(ImageFolder(glob_pattern=str(folder / "*.bmp"))) == 1
+        # Test __iter__
+        assert len(list(ImageFolder(glob_pattern=[str(folder / "*.jpg")]))) == jpg_cnt
+        assert len(list(ImageFolder(str(folder)))) == 8
+        # Test glob pattern on nested files
+        assert len(ImageFolder(glob_pattern=str(folder / "**/*.png"))) == 4
 
 
 @pytest.fixture
@@ -102,37 +102,36 @@ def input_image_folder(input_image_files) -> Path:
 def test_networked_camera():
     # Use a video to simulate a live camera and test motion detection
     test_video_file_path = "tests/data/videos/countdown.mp4"
-    Camera = NetworkedCamera(
+    with NetworkedCamera(
         stream_url=test_video_file_path, motion_detection_threshold=50
-    )
+    ) as camera:
 
-    # Get the first frame and the next frame where motion is detected. I keep the detection threshold low to make the test fast
-    i = iter(Camera)
-    frame1 = next(i)
-    while True:
-        # if we cannot get any motion detection (e.g. Threshold 100%), next() will throw an exception and fail the test
-        frame2 = next(i)
-        if not frame2.is_empty():
-            break
-    # frame1.show_image()
-    # frame2.show_image()
-    image_distance = np.sum(
-        cv2.absdiff(src1=frame1[0].to_numpy_array(), src2=frame2[0].to_numpy_array())
-    )
+        # Get the first frame and the next frame where motion is detected. I keep the detection threshold low to make the test fast
+        i = iter(camera)
+        frame1 = next(i)
+        while True:
+            # if we cannot get any motion detection (e.g. Threshold 100%), next() will throw an exception and fail the test
+            frame2 = next(i)
+            if not frame2.is_empty():
+                break
+        # frame1.show_image()
+        # frame2.show_image()
+        image_distance = np.sum(
+            cv2.absdiff(src1=frame1[0].to_numpy_array(), src2=frame2[0].to_numpy_array())
+        )
 
-    # Compute the diff by summing the delta between each pixel across the two images
-    del Camera
-    assert (
-        image_distance > 100000
-    )  # Even with little motion this number should exceed 100k
+        # Compute the diff by summing the delta between each pixel across the two images
+        assert (
+            image_distance > 100000
+        )  # Even with little motion this number should exceed 100k
 
 
 @mock.patch("landingai.pipeline.image_source.cv2")
 def test_webcam(mock_cv2):
     """Makes sure webcam is a networked camare that just uses camera index as stream URL"""
-    cam = Webcam()
-    assert isinstance(cam, NetworkedCamera)
-    mock_cv2.VideoCapture.assert_called_once_with(0)
+    with Webcam() as cam:
+        assert isinstance(cam, NetworkedCamera)
+        mock_cv2.VideoCapture.assert_called_once_with(0)
 
 
 @mock.patch(
@@ -140,17 +139,17 @@ def test_webcam(mock_cv2):
     return_value=PIL.Image.open("tests/data/images/cereal1.jpeg"),
 )
 def test_screenshot(mock_img_grab):
-    screenshot = Screenshot()
-    frame = next(screenshot)
-    assert isinstance(frame, FrameSet)
-    expected_img = PIL.Image.open("tests/data/images/cereal1.jpeg")
-    assert (np.asarray(frame[0].image) == np.asarray(expected_img)).all()
+    with Screenshot() as screenshot:
+        frame = next(screenshot)
+        assert isinstance(frame, FrameSet)
+        expected_img = PIL.Image.open("tests/data/images/cereal1.jpeg")
+        assert (np.asarray(frame[0].image) == np.asarray(expected_img)).all()
 
 
 def test_videofile_properties():
     video_file = "tests/data/videos/test.mp4"
-    video_source = pl.image_source.VideoFile(video_file, samples_per_second=8)
-    (s_fps, s_total_frames, t_fps, t_total_frames) = video_source.properties()
-    assert s_total_frames == 48
-    assert s_fps == 24
-    assert t_total_frames == 16
+    with pl.image_source.VideoFile(video_file, samples_per_second=8) as video_source:
+        (s_fps, s_total_frames, t_fps, t_total_frames) = video_source.properties()
+        assert s_total_frames == 48
+        assert s_fps == 24
+        assert t_total_frames == 16


### PR DESCRIPTION
Some image source classes are using `__del__` to cleanup resources, but using `__del__` for that is really tricky, specially because:
- CPython gc calls that at some point in the future after all the references to that object are gone, but no guarantee that this will happen immediatelly
- Reference cyles might postpone **a lot** the call to `__del__` method (maybe only call it at the end)
- A lot of specific behaviours described in CPython docs [here](https://docs.python.org/3/reference/datamodel.html#object.__del__)

Testing the `Webcam` class in ipython, for example, is basically impossible, since ipython holds reference to the object for an arbitrary amount of time. So, to create a new webcam object, we need to close the shell and open again. This probably happens in Collab/notebooks with other image sources too (we just don't see it happening because the operations implemented in `__del__` are not show stoppers today).

I'm proposing a more pythonic way of cleaning up resources: an explicit `close()` method for all image source objects, and also letting them behave as context managers (that by default calls `close()` when exiting the context).