### PR TITLE
Make image sources iterators return Frame instead of FrameSet, with compat layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project (v1.0.0 and above) adheres to [Semantic Versioning](https://sem
 
 > WARNING: currently the `landingai` library is in alpha version, and it's not strictly following [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Breaking changes will result a minor version bump instead of a major version bump. Feature releases will result in a patch version bump.
 
+## [0.3.0] - 2023-XX-YY
+
+### Major changes
+
+- [Image source iterators yielding single Frame](https://github.com/xxxxxx)
+
+
+### Migration Guide
+
+Whenever you iterate over an image source (`NetworkedCamera`, `Webcam`, etc), each iteration yields a single `Frame`, and not a `FrameSet`.
+But most `FrameSet` operations were migrated to `Frame` class, so you can still use the same API to manipulate the `Frame` object with very minor changes:
+
+1. `Frame` does not contain a `.frames` attribute, nor you can get index items from that. Instead, you should just use the `Frame` object directly (to do resize, check predictions, overlay predictions, etc).
+2. `Frame.save_image` receives a direct file path to where the frame image should be saved (not just a prefix, as it happens with `FrameSet`).
+
+
+
 ## [0.2.0] - 2023-07-12
 
 ### Major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project (v1.0.0 and above) adheres to [Semantic Versioning](https://sem
 
 > WARNING: currently the `landingai` library is in alpha version, and it's not strictly following [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Breaking changes will result a minor version bump instead of a major version bump. Feature releases will result in a patch version bump.
 
-## [0.3.0] - 2023-XX-YY
+## [0.3.0] - 2023-10-04
 
 ### Major changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project (v1.0.0 and above) adheres to [Semantic Versioning](https://sem
 
 ### Major changes
 
-- [Image source iterators yielding single Frame](https://github.com/xxxxxx)
+- [Image source iterators yielding single Frame](https://github.com/landing-ai/landingai-python/pull/125)
 
 
 ### Migration Guide
@@ -19,7 +19,7 @@ and this project (v1.0.0 and above) adheres to [Semantic Versioning](https://sem
 Whenever you iterate over an image source (`NetworkedCamera`, `Webcam`, etc), each iteration yields a single `Frame`, and not a `FrameSet`.
 But most `FrameSet` operations were migrated to `Frame` class, so you can still use the same API to manipulate the `Frame` object with very minor changes:
 
-1. `Frame` does not contain a `.frames` attribute, nor you can get index items from that. Instead, you should just use the `Frame` object directly (to do resize, check predictions, overlay predictions, etc).
+1. On `for frame in image_source:`, don't use `frame.frames[0]` anymore. Instead, you should just use the `frame` object directly (to do resize, check predictions, overlay predictions, etc).
 2. `Frame.save_image` receives a direct file path to where the frame image should be saved (not just a prefix, as it happens with `FrameSet`).
 
 

--- a/examples/apps/license-plate-ocr/app.py
+++ b/examples/apps/license-plate-ocr/app.py
@@ -51,7 +51,7 @@ def extract_frames(video):
     )
     frames = []
     with st.spinner(text="Extracting frames from video file..."):
-        frames.extend(frame_info.frames[0].image for frame_info in video_source)
+        frames.extend(frame_info.image for frame_info in video_source)
     st.success("Frame Extraction Finished!")
     with st.expander("Preview extracted frames"):
         selected_img = image_select(

--- a/examples/license-plate-ocr-notebook/license_plate_ocr.ipynb
+++ b/examples/license-plate-ocr-notebook/license_plate_ocr.ipynb
@@ -73,7 +73,7 @@
     "video_file_path = \"/tmp/license-plates.mov\"\n",
     "\n",
     "video_source = VideoFile(video_file_path, samples_per_second=1)\n",
-    "frames = [f.frames[0].image for f in video_source]\n",
+    "frames = [f.image for f in video_source]\n",
     "print(f\"Extracted {len(frames)} frames from the above video\")"
    ]
   },

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -4,6 +4,7 @@
 import logging
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Union, cast
+import warnings
 
 import cv2
 import imageio
@@ -78,6 +79,15 @@ class Frame(BaseModel):
 
     metadata: Dict[str, Any] = {}
     """An optional collection of metadata"""
+
+    @property
+    def frames(self) -> List["Frame"]:
+        """Returns a list with a single frame"""
+        warnings.warn(
+            "frame.frames[x].<method> is deprecated and will be removed in future versions. "
+            "Use frame.<method> instead"
+        )
+        return [self]
 
     @classmethod
     def from_image(cls, uri: str, metadata: Optional[Dict[str, Any]] = {}) -> "Frame":

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -154,7 +154,7 @@ class Frame(BaseModel):
 
     def show_image(
         self, image_src: str = "", clear_nb_cell: bool = False, *, include_predictions: bool = False
-    ) -> "FrameSet":
+    ) -> "Frame":
         """Open an a window and display all the images.
         Parameters
         ----------
@@ -186,6 +186,7 @@ class Frame(BaseModel):
                 self.image.show()
             else:
                 self.other_images[image_src].show()
+        return self
 
     def save_image(
         self, path: str, format: str = "png", *, include_predictions: bool = False

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 
 from landingai.common import ClassificationPrediction, Prediction
 from landingai.notebook_utils import is_running_in_notebook
-from landingai.pipeline import image_source
 from landingai.predict import Predictor
 from landingai.storage.data_access import fetch_from_uri
 from landingai.visualize import overlay_predictions

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -320,16 +320,8 @@ class FrameSet(BaseModel):
         width: The requested width in pixels.
         height: The requested width in pixels.
         """
-        if width is None and height is None:  # No resize needed
-            return self
         for frame in self.frames:
-            # Compute the final dimensions on the first image
-            if width is None:
-                width = int(height * float(frame.image.size[0] / frame.image.size[1]))  # type: ignore
-            if height is None:
-                height = int(width * float(frame.image.size[1] / frame.image.size[0]))
-            if frame.image.size[0] > width or frame.image.size[1] > height:
-                frame.image = frame.image.resize((width, height))
+            frame.downsize(width, height)
         return self
 
     def save_image(

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -514,6 +514,20 @@ class FrameSet(BaseModel):
         self.frames.extend(frs.frames)
         return self
 
+    def append(self, fr: Frame) -> None:
+        """Add a Frame into this FrameSet
+
+        Parameters
+        ----------
+        fr : Frame
+            Frame to be added at the end of the current one
+
+        Returns
+        -------
+        FrameSet
+        """
+        self.frames.append(fr)
+
     def apply(self, function: Callable[[Frame], Frame] = lambda f: f) -> "FrameSet":
         """Apply a function to all frames
 

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -125,6 +125,12 @@ class Frame(BaseModel):
         self.predictions = PredictionList(predictor.predict(np.asarray(self.image)))  # type: ignore
         return self
 
+    def overlay_predictions(self, options: Optional[Dict[str, Any]] = None) -> "Frame":
+        self.other_images["overlay"] = overlay_predictions(
+            cast(List[Prediction], self.predictions), self.image, options
+        )
+        return self
+
     def to_numpy_array(self, image_src: str = "") -> np.ndarray:
         """Return a numpy array using RGB channel ordering. If this array is passed to OpenCV, you will need to convert it to BGR
 
@@ -277,9 +283,7 @@ class FrameSet(BaseModel):
         self, options: Optional[Dict[str, Any]] = None
     ) -> "FrameSet":  # TODO: Optional where to store
         for frame in self.frames:
-            frame.other_images["overlay"] = overlay_predictions(
-                cast(List[Prediction], frame.predictions), frame.image, options
-            )
+            frame.overlay_predictions(options)
         return self
 
     def resize(

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -153,7 +153,11 @@ class Frame(BaseModel):
         return np.asarray(img)
 
     def show_image(
-        self, image_src: str = "", clear_nb_cell: bool = False, *, include_predictions: bool = False
+        self,
+        image_src: str = "",
+        clear_nb_cell: bool = False,
+        *,
+        include_predictions: bool = False,
     ) -> "Frame":
         """Open an a window and display all the images.
         Parameters
@@ -500,7 +504,11 @@ class FrameSet(BaseModel):
         return self
 
     def show_image(
-        self, image_src: str = "", clear_nb_cell: bool = False, *, include_predictions: bool = False
+        self,
+        image_src: str = "",
+        clear_nb_cell: bool = False,
+        *,
+        include_predictions: bool = False,
     ) -> "FrameSet":
         """Open an a window and display all the images.
         Parameters
@@ -516,7 +524,9 @@ class FrameSet(BaseModel):
                 include_predictions = True
 
         for frame in self.frames:
-            frame.show_image(clear_nb_cell=clear_nb_cell, include_predictions=include_predictions)
+            frame.show_image(
+                clear_nb_cell=clear_nb_cell, include_predictions=include_predictions
+            )
 
         # # TODO: Implement image stacking when we have multiple frames (https://answers.opencv.org/question/175912/how-to-display-multiple-images-in-one-window/)
         # """Open an OpenCV window and display all the images. This call will stop the execution until a key is pressed.

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -120,7 +120,7 @@ class Frame(BaseModel):
         -------
         Frame
         """
-        # TODO: Make is_bgr and enum and support grayscale, rgba (what can PIL autodetect?)
+        # TODO: Make is_bgr an enum and support grayscale, rgba (what can PIL autodetect?)
         if is_bgr:
             array = cv2.cvtColor(array, cv2.COLOR_BGR2RGB)
         im = Image.fromarray(array)
@@ -158,11 +158,11 @@ class Frame(BaseModel):
         *,
         include_predictions: bool = False,
     ) -> "Frame":
-        """Open an a window and display all the images.
+        """Open a window and display all the images.
         Parameters
         ----------
         image_src (deprecated): if empty the source image will be displayed. Otherwise the image will be selected from `other_images`
-        include_predictions: If the image has predictions, should it be overlayed on top of the image?
+        include_predictions: If the image has predictions, should it be overlaid on top of the image?
         """
         if image_src:
             warnings.warn(
@@ -200,7 +200,7 @@ class Frame(BaseModel):
         ----------
         path: File path for the output image
         format: File format for the output image. Defaults to "png"
-        include_predictions: If the image has predictions, should it be overlayed on top of the image?
+        include_predictions: If the image has predictions, should it be overlaid on top of the image?
         """
         if include_predictions:
             img = self.other_images["overlay"]
@@ -385,7 +385,7 @@ class FrameSet(BaseModel):
         ----------
         filename_prefix : path and name prefix for the image file
         image_src: (deprecated) if empty the source image will be saved. Otherwise the image will be selected from `other_images`
-        include_predictions: If the image has predictions, should it be overlayed on top of the image?
+        include_predictions: If the image has predictions, should it be overlaid on top of the image?
         """
         if image_src:
             warnings.warn(
@@ -509,11 +509,11 @@ class FrameSet(BaseModel):
         *,
         include_predictions: bool = False,
     ) -> "FrameSet":
-        """Open an a window and display all the images.
+        """Open a window and display all the images.
         Parameters
         ----------
         image_src (deprecated): if empty the source image will be displayed. Otherwise the image will be selected from `other_images`
-        include_predictions: If the image has predictions, should it be overlayed on top of the image?
+        include_predictions: If the image has predictions, should it be overlaid on top of the image?
         """
         if image_src:
             warnings.warn(

--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -65,7 +65,7 @@ class PredictionList(List[ClassificationPrediction]):
 
 
 class Frame(BaseModel):
-    """A Frame stores a main image, its metadata and potentially other derived images. This class will be mostly used internally by the FrameSet clase. A pipeline will `FrameSet` since it is more general and a can also keep new `Frames` extracted from existing ones"""
+    """A Frame stores a main image, its metadata and potentially other derived images."""
 
     image: Image.Image
     """Main image generated typically at the beginning of a pipeline"""
@@ -78,6 +78,43 @@ class Frame(BaseModel):
 
     metadata: Dict[str, Any] = {}
     """An optional collection of metadata"""
+
+    @classmethod
+    def from_image(cls, uri: str, metadata: Optional[Dict[str, Any]] = {}) -> "Frame":
+        """Creates a Frame from an image file
+
+        Parameters
+        ----------
+        uri : URI to file (local or remote)
+
+        Returns
+        -------
+        Frame : New Frame enclosing the image
+        """
+
+        image = Image.open(str(fetch_from_uri(uri)))
+        return cls(image=image, metadata=metadata)
+
+    @classmethod
+    def from_array(cls, array: np.ndarray, is_bgr: bool = True) -> "Frame":
+        """Creates a Frame from a image encode as ndarray
+
+        Parameters
+        ----------
+        array : np.ndarray
+            Image
+        is_bgr : bool, optional
+            Assume OpenCV's BGR channel ordering? Defaults to True
+
+        Returns
+        -------
+        Frame
+        """
+        # TODO: Make is_bgr and enum and support grayscale, rgba (what can PIL autodetect?)
+        if is_bgr:
+            array = cv2.cvtColor(array, cv2.COLOR_BGR2RGB)
+        im = Image.fromarray(array)
+        return cls(image=im)
 
     def run_predict(self, predictor: Predictor) -> "Frame":
         """Run a cloud inference model
@@ -97,6 +134,55 @@ class Frame(BaseModel):
         """
         img = self.image if image_src == "" else self.other_images[image_src]
         return np.asarray(img)
+
+    def save_image(self, path: str, format: str = "png") -> None:
+        """Save the image to path
+
+        Parameters
+        ----------
+        path: File path for the output image
+        format: File format for the output image. Defaults to "png"
+        """
+        self.image.save(path, format=format.upper())
+
+    def resize(
+        self, width: Optional[int] = None, height: Optional[int] = None
+    ) -> "Frame":
+        """Resizes the frame to the given dimensions. If width or height is missing the resize will preserve the aspect ratio.
+        Parameters
+        ----------
+        width: The requested width in pixels.
+        height: The requested width in pixels.
+        """
+        if width is None and height is None:  # No resize needed
+            return self
+
+        if width is None:
+            width = int(height * float(self.image.size[0] / self.image.size[1]))  # type: ignore
+        if height is None:
+            height = int(width * float(self.image.size[1] / self.image.size[0]))
+        self.image = self.image.resize((width, height))
+        return self
+
+    def downsize(
+        self, width: Optional[int] = None, height: Optional[int] = None
+    ) -> "Frame":
+        """Resize only if the image is larger than the expected dimensions,
+        Parameters
+        ----------
+        width: The requested width in pixels.
+        height: The requested width in pixels.
+        """
+        if width is None and height is None:  # No resize needed
+            return self
+        # Compute the final dimensions on the first image
+        if width is None:
+            width = int(height * float(self.image.size[0] / self.image.size[1]))  # type: ignore
+        if height is None:
+            height = int(width * float(self.image.size[1] / self.image.size[0]))
+        if self.image.size[0] > width or self.image.size[1] > height:
+            self.image = self.image.resize((width, height))
+        return self
 
     class Config:
         arbitrary_types_allowed = True
@@ -125,9 +211,7 @@ class FrameSet(BaseModel):
         -------
         FrameSet : New FrameSet containing a single image
         """
-
-        im = Image.open(str(fetch_from_uri(uri)))
-        return cls(frames=[Frame(image=im, metadata=metadata)])
+        return cls(frames=[Frame.from_image(uri=uri, metadata=metadata)])
 
     @classmethod
     def from_array(cls, array: np.ndarray, is_bgr: bool = True) -> "FrameSet":
@@ -144,11 +228,7 @@ class FrameSet(BaseModel):
         -------
         FrameSet
         """
-        # TODO: Make is_bgr and enum and support grayscale, rgba (what can PIL autodetect?)
-        if is_bgr:
-            array = cv2.cvtColor(array, cv2.COLOR_BGR2RGB)
-        im = Image.fromarray(array)
-        return cls(frames=[Frame(image=im)])
+        return cls(frames=[Frame.from_array(array=array, is_bgr=is_bgr)])
 
     # TODO: Is it worth to emulate a full container? - https://docs.python.org/3/reference/datamodel.html#emulating-container-types
     def __getitem__(self, key: int) -> Frame:
@@ -214,12 +294,7 @@ class FrameSet(BaseModel):
         if width is None and height is None:  # No resize needed
             return self
         for frame in self.frames:
-            # Compute the final dimensions on the first image
-            if width is None:
-                width = int(height * float(frame.image.size[0] / frame.image.size[1]))  # type: ignore
-            if height is None:
-                height = int(width * float(frame.image.size[1] / frame.image.size[0]))
-            frame.image = frame.image.resize((width, height))
+            frame.resize(width, height)
         return self
 
     def downsize(
@@ -243,7 +318,9 @@ class FrameSet(BaseModel):
                 frame.image = frame.image.resize((width, height))
         return self
 
-    def save_image(self, filename_prefix: str, image_src: str = "") -> "FrameSet":
+    def save_image(
+        self, filename_prefix: str, image_src: str = "", format: str = "png"
+    ) -> "FrameSet":
         """Save all the images on the FrameSet to disk (as PNG)
 
         Parameters
@@ -251,14 +328,25 @@ class FrameSet(BaseModel):
         filename_prefix : path and name prefix for the image file
         image_src : if empty the source image will be saved. Otherwise the image will be selected from `other_images`
         """
-        timestamp = datetime.now().strftime(
-            "%Y%m%d-%H%M%S"
-        )  # TODO saving faster than 1 sec will cause image overwrite
-        c = 0
-        for frame in self.frames:
-            img = frame.image if image_src == "" else frame.other_images[image_src]
-            img.save(f"{filename_prefix}_{timestamp}_{image_src}_{c}.png", format="PNG")
-            c += 1
+        # If there is only one frame, save it with the given prefix without timestamp
+        if len(self.frames) == 1:
+            self.frames[0].save_image(
+                f"{filename_prefix}.{format.lower()}", format=format.upper()
+            )
+        else:
+            # TODO: deprecate this behavior. Using timestamp here makes it really hard
+            # to find the images later. We should probably use a counter instead (like "prefix_{i}.png")
+            timestamp = datetime.now().strftime(
+                "%Y%m%d-%H%M%S"
+            )  # TODO saving faster than 1 sec will cause image overwrite
+            c = 0
+            for frame in self.frames:
+                img = frame.image if image_src == "" else frame.other_images[image_src]
+                img.save(
+                    f"{filename_prefix}_{timestamp}_{image_src}_{c}.{format.lower()}",
+                    format=format.upper(),
+                )
+                c += 1
         return self
 
     def save_video(

--- a/landingai/pipeline/image_source.py
+++ b/landingai/pipeline/image_source.py
@@ -22,7 +22,7 @@ import numpy as np
 from pydantic import BaseModel, PrivateAttr
 
 from landingai.image_source_ops import sample_images_from_video
-from landingai.pipeline.frameset import Frame, FrameSet
+from landingai.pipeline.frameset import Frame
 from landingai.storage.data_access import fetch_from_uri
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "landingai"
-version = "0.2.45"
+version = "0.3.0"
 description = "Helper library for interacting with Landing AI LandingLens"
 authors = ["Landing AI <dev@landing.ai>"]
 readme = "README.md"
@@ -20,7 +20,7 @@ python = ">=3.8,<4.0"
 
 opencv-python = ">=4.5,<5.0"  # about 87MB (exclude transitive dependencies)
 numpy = ">=1.21.0,<2.0.0"
-pillow = "9.*" # Version 10.0.0 had a issue on FreeTypeFont that will be fixed on the next release 
+pillow = "9.*" # Version 10.0.0 had a issue on FreeTypeFont that will be fixed on the next release
 pydantic = { version = "1.*", extras = ["dotenv"] } # Version 2 has breaking changes (in particular to seetings)
 requests = "2.*"
 # snowflake-connector-python = "3.0.*"  # about 51MB (exclude transitive dependencies)

--- a/tests/unit/landingai/pipeline/test_frameset.py
+++ b/tests/unit/landingai/pipeline/test_frameset.py
@@ -133,6 +133,19 @@ def test_od_predictions_filter_label():
         get_frame_with_od_coffee_prediction,
     ],
 )
+def test_frame_dot_frames_returns_all_available_frames(frame_getter):
+    # TODO: This test should be deprecated together with Frame.frames property
+    frame = frame_getter()
+    assert isinstance(frame.frames[0].image.size, tuple)
+
+
+@pytest.mark.parametrize(
+    "frame_getter",
+    [
+        get_frameset_with_od_coffee_prediction,
+        get_frame_with_od_coffee_prediction,
+    ],
+)
 def test_resize(frame_getter):
     frame = frame_getter()
     frame.resize(width=100, height=100)

--- a/tests/unit/landingai/pipeline/test_frameset.py
+++ b/tests/unit/landingai/pipeline/test_frameset.py
@@ -136,6 +136,8 @@ def test_od_predictions_filter_label():
 def test_frame_dot_frames_returns_all_available_frames(frame_getter):
     # TODO: This test should be deprecated together with Frame.frames property
     frame = frame_getter()
+    assert isinstance(frame.frames, list)
+    assert len(frame.frames) == 1
     assert isinstance(frame.frames[0].image.size, tuple)
 
 

--- a/tests/unit/landingai/pipeline/test_image_source.py
+++ b/tests/unit/landingai/pipeline/test_image_source.py
@@ -9,7 +9,7 @@ import PIL.Image
 import pytest
 
 import landingai.pipeline as pl
-from landingai.pipeline.frameset import FrameSet
+from landingai.pipeline.frameset import Frame
 from landingai.pipeline.image_source import (
     ImageFolder,
     NetworkedCamera,
@@ -24,20 +24,20 @@ def test_image_folder_for_loop(input_image_folder):
     expected_files.sort()
     with ImageFolder(input_image_folder) as folder:
         assert len(list(folder)) == 8
-        for i, frames in enumerate(folder):
-            assert isinstance(frames, FrameSet)
-            assert frames[0].image.size == (20, 20)
-            assert frames[0].metadata["image_path"] == expected_files[i]
+        for i, frame in enumerate(folder):
+            assert isinstance(frame, Frame)
+            assert frame.image.size == (20, 20)
+            assert frame.metadata["image_path"] == expected_files[i]
         assert len(list(folder)) == 8
 
 
 def test_image_folder_with_input_files(input_image_files):
     with ImageFolder(input_image_files) as folder:
         assert len(list(folder)) == 8
-        for i, frames in enumerate(folder):
-            assert isinstance(frames, FrameSet)
-            assert frames[0].image.size == (20, 20)
-            assert frames[0].metadata["image_path"] == input_image_files[i]
+        for i, frame in enumerate(folder):
+            assert isinstance(frame, Frame)
+            assert frame.image.size == (20, 20)
+            assert frame.metadata["image_path"] == input_image_files[i]
 
 
 def test_image_folder_with_glob_patterns(input_image_folder):
@@ -111,14 +111,12 @@ def test_networked_camera():
         while True:
             # if we cannot get any motion detection (e.g. Threshold 100%), next() will throw an exception and fail the test
             frame2 = next(i)
-            if not frame2.is_empty():
+            if frame2 is not None:
                 break
         # frame1.show_image()
         # frame2.show_image()
         image_distance = np.sum(
-            cv2.absdiff(
-                src1=frame1[0].to_numpy_array(), src2=frame2[0].to_numpy_array()
-            )
+            cv2.absdiff(src1=frame1.to_numpy_array(), src2=frame2.to_numpy_array())
         )
 
         # Compute the diff by summing the delta between each pixel across the two images
@@ -142,9 +140,9 @@ def test_webcam(mock_cv2):
 def test_screenshot(mock_img_grab):
     with Screenshot() as screenshot:
         frame = next(screenshot)
-        assert isinstance(frame, FrameSet)
+        assert isinstance(frame, Frame)
         expected_img = PIL.Image.open("tests/data/images/cereal1.jpeg")
-        assert (np.asarray(frame[0].image) == np.asarray(expected_img)).all()
+        assert (np.asarray(frame.image) == np.asarray(expected_img)).all()
 
 
 def test_videofile_properties():


### PR DESCRIPTION
When we iterate over a `NetworkedCamera` or any other image source, each iteration returns a `FrameSet` with a single `Frame` inside. This behavior is a bit confusing for end users, with few compatibility between the two objects and most operations ending up relying on `frame.frames[0].do_something` anyway.

This PR addresses this by:
- Adding a compatibility interface to do frame operations (like resize, downsize, save_image, etc) on `Frame` object itself, with `FrameSet` calling the underlying `Frame` methods.
- Adding a `Frame.frames` property, marked as deprecated, so that `for frame in img_source_obj: frame.frames[-1].resize(xxx)`, for example, wont break until we bump a major version.
- Added a few test cases to ensure the compatibility of those methods
- Returning, on every `landingai.pipeline.image_source` class iterator, a `Frame` object instead of a `FrameSet` (so we leave `FrameSet` as a helper to build sequences of frames, like videos).
- A small refactoring on `NetworkedCamera` when the motion threshold is enabled: block the iterator while no new frame is available. This way, the end user will not need to check if the frame is empty. The iterator will only yield new `Frame` whenever motion is detected.