### PR TITLE
Improve ocr app

### DIFF
--- a/examples/apps/ocr/app.py
+++ b/examples/apps/ocr/app.py
@@ -27,7 +27,7 @@ Image.MAX_IMAGE_PIXELS = None
 
 class DetModel(str, Enum):
     AUTO_DETECT = "multi-text"
-    MANUAL_ROI = "single-text"
+    MANUAL_ROI = "multi-text_roi"
 
 
 # Streamlit app code
@@ -99,6 +99,8 @@ def main():
             key="th_slider",
         )
         mode = DetModel[detection_mode].value
+        if mode.startswith("multi-text"):
+            mode = "multi-text"
         key = get_api_key_or_use_default()
         # Run ocr on the whole image
         if input_images is not None and st.button("Run"):

--- a/examples/apps/ocr/roi.py
+++ b/examples/apps/ocr/roi.py
@@ -14,7 +14,7 @@ def draw_region_of_interests(image: PIL.Image.Image) -> Dict[str, Any]:
         st.sidebar.color_picker("Annotation color: ", "#EA1010") + "77"
     )  # for alpha from 00 to FF
     st.sidebar.write(
-        "To draw 4 point polygon left click and draw 3 edges (must in **clockwise order**) and then right click for the 4th point to close the polygon"
+        "To draw 4 point polygon left click and draw 3 edges (must be in **clockwise order**) and then right click for the 4th point to close the polygon"
     )
     mode = (
         "polygon"


### PR DESCRIPTION
Fix a bug discovered by the QA team: 
Use multi-line mode when user selects "Manual ROI". This helps for both single-line and multi-line cases with a slight compromise of latency.

See: https://app.asana.com/0/1203451328302791/1205645191640208/f and https://landingai.slack.com/archives/C0138KFUBMY/p1696533981595169?thread_ts=1696525180.762149&cid=C0138KFUBMY