### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ All the examples in this repo can be run locally.
 To give you some guidance, here's how you can run the [`rtsp-capture`](https://github.com/landing-ai/landingai-python/tree/main/examples/capture-service) example locally in a shell environment:
 
 1. Clone the repo to local: `git clone https://github.com/landing-ai/landingai-python.git`
-2. Install the library: `poetry install --with examples` (See the [Developer Guide](https://landing-ai.github.io/landingai-python/landingai.html#developer-guide) for how to install `poetry`)
+2. Install the library: `poetry install --with examples` (See the [poetry docs](https://python-poetry.org/docs/#installation) for how to install `poetry`)
 3. Activate the virtual environment: `poetry shell`
 4. Run: `python landingai-python/examples/capture-service/run.py`


### PR DESCRIPTION
Linking directly to poetry docs on "how to install poetry", instead of our own documentation (this exact link doesn't exist anymore, after the migration of our docs).