### PR TITLE
Bugfix: run prediction on RGBA images

### DIFF
--- a/landingai/pipeline/frameset.py
+++ b/landingai/pipeline/frameset.py
@@ -132,7 +132,7 @@ class Frame(BaseModel):
         ----------
         predictor: the model to be invoked.
         """
-        self.predictions = PredictionList(predictor.predict(np.asarray(self.image)))  # type: ignore
+        self.predictions = PredictionList(predictor.predict(self.image))  # type: ignore
         return self
 
     def overlay_predictions(self, options: Optional[Dict[str, Any]] = None) -> "Frame":
@@ -333,7 +333,7 @@ class FrameSet(BaseModel):
         """
 
         for frame in self.frames:
-            frame.predictions = predictor.predict(np.asarray(frame.image))  # type: ignore
+            frame.run_predict(predictor)
         return self
 
     def overlay_predictions(

--- a/tests/unit/landingai/pipeline/test_frameset.py
+++ b/tests/unit/landingai/pipeline/test_frameset.py
@@ -13,6 +13,7 @@ from landingai.pipeline.frameset import FrameSet, Frame, PredictionList
 def get_frameset() -> FrameSet:
     return FrameSet.from_image("tests/data/images/cereal1.jpeg")
 
+
 def get_frame() -> Frame:
     return Frame.from_image("tests/data/images/cereal1.jpeg")
 


### PR DESCRIPTION
`Frame.run_predict` is converting the PIL image to numpy array before sending it to predictors. This breaks for `Frames` generated from RGBA PNG images.

This PR fixes that by sending the original PIL image, which is already treated correctly by `serialize_image` function (called by predictors).