### PR TITLE
Send inference data for ETL and tracking

### DIFF
--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -103,7 +103,7 @@ class Predictor:
         """Build the HTTP headers for the request to the Cloud inference endpoint(s)."""
         tracked_properties = get_runtime_environment_info()
         if extra_x_event:
-            tracked_properties |= extra_x_event
+            tracked_properties.update(extra_x_event)
         tracking_data = {
             "event": "inference",
             "action": "POST",

--- a/landingai/predict.py
+++ b/landingai/predict.py
@@ -24,7 +24,7 @@ from landingai.common import (
     SegmentationPrediction,
 )
 from landingai.exceptions import HttpResponse, RateLimitExceededError
-from landingai.telemetry import get_runtime_environment_info, is_running_in_pytest
+from landingai.telemetry import get_runtime_environment_info
 from landingai.timer import Timer
 from landingai.utils import load_api_credential, serialize_image
 
@@ -68,7 +68,11 @@ class Predictor:
 
         self._endpoint_id = endpoint_id
         self._api_credential = load_api_credential(api_key)
-        headers = self._build_default_headers(self._api_credential)
+        extra_x_event = {
+            "endpoint_id": self._endpoint_id,
+            "model_type": "fast_and_easy",
+        }
+        headers = self._build_default_headers(self._api_credential, extra_x_event)
         self._session = _create_session(Predictor._url, self._num_retry, headers)
 
     def _check_connectivity(
@@ -93,11 +97,22 @@ class Predictor:
         sock.close()
         return result == 0
 
-    def _build_default_headers(self, api_key: APIKey) -> Dict[str, str]:
+    def _build_default_headers(
+        self, api_key: APIKey, extra_x_event: Optional[Dict[str, str]] = None
+    ) -> Dict[str, str]:
         """Build the HTTP headers for the request to the Cloud inference endpoint(s)."""
+        tracked_properties = get_runtime_environment_info()
+        if extra_x_event:
+            tracked_properties |= extra_x_event
+        tracking_data = {
+            "event": "inference",
+            "action": "POST",
+            "properties": tracked_properties,
+        }
         return {
             "contentType": "multipart/form-data",
             "apikey": api_key.api_key,
+            "X-event": json.dumps(tracking_data),
         }
 
     @retry(
@@ -133,17 +148,15 @@ class Predictor:
         """
         buffer_bytes = serialize_image(image)
         files = {"file": buffer_bytes}
-        payload = {
+        query_params = {
             "endpoint_id": self._endpoint_id,
-            "device_type": "pylib",
         }
-        _add_default_query_params(payload)
         data = {"metadata": metadata.json()} if metadata else None
         return _do_inference(
             self._session,
             Predictor._url,
             files,
-            payload,
+            query_params,
             _CloudExtractor,
             data=data,
         )
@@ -173,7 +186,10 @@ class OcrPredictor(Predictor):
         """
         self._threshold = threshold
         self._api_credential = load_api_credential(api_key)
-        headers = self._build_default_headers(self._api_credential)
+        extra_x_event = {
+            "model_type": "ocr",
+        }
+        headers = self._build_default_headers(self._api_credential, extra_x_event)
         self._session = _create_session(Predictor._url, self._num_retry, headers)
 
     @retry(
@@ -223,13 +239,11 @@ class OcrPredictor(Predictor):
         if rois := kwargs.get("regions_of_interest", []):
             data["rois"] = serialize_rois(rois, mode)
 
-        payload: Dict[str, Any] = {"device_type": "pylib"}
-        _add_default_query_params(payload)
         preds = _do_inference(
             self._session,
             OcrPredictor._url,
             files,
-            payload,
+            {},
             _OcrExtractor,
             data=data,
         )
@@ -802,13 +816,3 @@ def _do_inference(
     response.raise_for_status()
     json_dict = response.json()
     return extractor_class.extract_prediction(json_dict)
-
-
-def _add_default_query_params(payload: Dict[str, Any]) -> None:
-    """Add default query params to the payload for tracking and analytics purpose."""
-    env_info = get_runtime_environment_info()
-    payload["runtime"] = env_info["runtime"]
-    if is_running_in_pytest():
-        # Don't add extra query params if pytest is running, otherwise it will fail some unit tests
-        return
-    payload["lib_version"] = env_info["lib_version"]

--- a/tests/data/responses/default_vp_model_response.yaml
+++ b/tests/data/responses/default_vp_model_response.yaml
@@ -25,4 +25,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 200
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=63035608-9d24-4342-8042-e4b08e084fde&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=63035608-9d24-4342-8042-e4b08e084fde

--- a/tests/data/responses/v1_predict_status_300.yaml
+++ b/tests/data/responses/v1_predict_status_300.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 300
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43

--- a/tests/data/responses/v1_predict_status_400.yaml
+++ b/tests/data/responses/v1_predict_status_400.yaml
@@ -6,4 +6,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 400
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4

--- a/tests/data/responses/v1_predict_status_401.yaml
+++ b/tests/data/responses/v1_predict_status_401.yaml
@@ -6,4 +6,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 401
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43

--- a/tests/data/responses/v1_predict_status_403.yaml
+++ b/tests/data/responses/v1_predict_status_403.yaml
@@ -6,4 +6,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 403
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=dfa79692-75eb-4a48-b02e-b273751adbae&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=dfa79692-75eb-4a48-b02e-b273751adbae

--- a/tests/data/responses/v1_predict_status_404.yaml
+++ b/tests/data/responses/v1_predict_status_404.yaml
@@ -7,4 +7,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 404
-    url: https://predict.app.landing.ai/v0/foo?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/v0/foo?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43

--- a/tests/data/responses/v1_predict_status_422.yaml
+++ b/tests/data/responses/v1_predict_status_422.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 422
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=12345&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=12345

--- a/tests/data/responses/v1_predict_status_429.yaml
+++ b/tests/data/responses/v1_predict_status_429.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 429
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43

--- a/tests/data/responses/v1_predict_status_500.yaml
+++ b/tests/data/responses/v1_predict_status_500.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 500
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4

--- a/tests/data/responses/v1_predict_status_503.yaml
+++ b/tests/data/responses/v1_predict_status_503.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 503
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4

--- a/tests/data/responses/v1_predict_status_504.yaml
+++ b/tests/data/responses/v1_predict_status_504.yaml
@@ -5,4 +5,4 @@ responses:
     content_type: text/plain
     method: POST
     status: 504
-    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4&device_type=pylib&runtime=pytest
+    url: https://predict.app.landing.ai/inference/v1/predict?endpoint_id=db90b68d-cbfd-4a9c-8dc2-ebc4c3f6e5a4

--- a/tests/unit/landingai/test_predict.py
+++ b/tests/unit/landingai/test_predict.py
@@ -229,7 +229,7 @@ def test_predict_matching_expected_request_body():
     img = Image.open(img_path)
     expected_request_files = {"file": _read_image_as_jpeg_bytes(img_path)}
     responses.post(
-        url="https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43&device_type=pylib&runtime=pytest",
+        url="https://predict.app.landing.ai/inference/v1/predict?endpoint_id=8fc1bc53-c5c1-4154-8cc1-a08f2e17ba43",
         match=[multipart_matcher(expected_request_files)],
         json={
             "backbonetype": None,


### PR DESCRIPTION
Motivation

Adopt the infra team's new feature to emit data to the ETL pipeline and for analytics.

Tracked properties:
1. endpoint_id
2. model_type
3. lib_type
4. lib_version
5. python_version
6. os
7. runtime