### PR TITLE
Expose cloud and edge inference speed metrics

### DIFF
--- a/examples/capture-service/run.py
+++ b/examples/capture-service/run.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         _LOGGER.info(
             f"Inference time {(datetime.now()-start_time).total_seconds():.2f} sec"
         )
-        _LOGGER.info(f"Detailed inference metrics {cloud_sky_model.get_metrics()}")
+        _LOGGER.debug(f"Detailed inference metrics {cloud_sky_model.get_metrics()}")
         # Do some further processing on the pipeline
         frame = (
             frame.overlay_predictions()


### PR DESCRIPTION
This change helps users get a breakdown of the time spent during inference. This is useful to experiment with different inference pipelines.