### PR TITLE
Fix OCR predictor after performance metrics addition

### DIFF
--- a/tests/data/responses/test_ocr_predict.yaml
+++ b/tests/data/responses/test_ocr_predict.yaml
@@ -1,0 +1,8 @@
+responses:
+  - response:
+      auto_calculate_content_length: false
+      body: '[[{"text":"test","score":0.6326617002487183,"location":[{"x":598,"y":248},{"x":818,"y":250},{"x":818,"y":303},{"x":598,"y":301}]}]]'
+      content_type: text/plain
+      method: POST
+      status: 200
+      url: https://app.landing.ai/ocr/v1/detect-text

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -68,8 +68,8 @@ def test_od_predict():
     expected_scores = [0.9997851252555847, 0.9983770251274109, 0.9983124732971191]
     expected_bboxes = [
         (432, 1036, 653, 1204),
-        (948, 1592, 1122, 1798),
-        (1518, 1413, 1991, 1799),
+        (948, 1592, 1123, 1799),
+        (1518, 1413, 1992, 1800),
     ]
     for i, pred in enumerate(preds):
         assert pred.label_name == "Screw"

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -67,7 +67,7 @@ def test_od_predict():
     assert len(preds) == 3, "Result should not be empty or None"
     expected_scores = [0.9997851252555847, 0.9983770251274109, 0.9983124732971191]
     expected_bboxes = [
-        (432, 1036, 652, 1203),
+        (432, 1036, 653, 1204),
         (948, 1592, 1122, 1798),
         (1518, 1413, 1991, 1799),
     ]

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -146,7 +146,6 @@ def test_class_predict():
     img_with_masks.save("tests/output/test_class.jpg")
 
 
-@pytest.mark.skip
 def test_ocr_predict():
     Path("tests/output").mkdir(parents=True, exist_ok=True)
     predictor = OcrPredictor(api_key=_API_KEY)
@@ -156,33 +155,32 @@ def test_ocr_predict():
     preds = predictor.predict(img, mode="multi-text")
     logging.info(preds)
     expected_texts = [
-        "公司名称",
-        "业务方向",
-        "Anysphere",
         "AI工具",
-        "Atomic Semi",
-        "芯片",
-        "Cursor",
-        "代码编辑",
-        "Diagram",
-        "设计",
-        "Harvey",
         "AI法律顾问",
-        "Kick",
-        "会计软件",
-        "Milo",
-        "家长虚拟助理",
-        "qqbot.dev",
-        "开发者工具",
-        "EdgeDB",
-        "开源数据库",
-        "Mem Labs",
-        "笔记应用",
-        "Speak",
-        "英语学习",
+        "Anysphere",
+        "Atomic Semi",
+        "Cursor",
         "Descript",
-        "音视频编辑",
-        "量子位",
+        "Diagram",
+        "EdgeDB",
+        "Harvey",
+        "Kick",
+        "Mem Labs",
+        "Milo",
+        "Speak",
+        "qqbot.dev",
+        "业务方向",
+        "代码编辑",
+        "会计软件",
+        "公司名称",
+        "家长虚拟助理",
+        "开发者工具",
+        "开源数据库",
+        "笔记应用",
+        "芯片",
+        "英语学习",
+        "设计",
+        "音视频编辑子位",
     ]
     preds = sorted(preds, key=lambda x: x.text)
     expected_texts = sorted(expected_texts)
@@ -206,12 +204,12 @@ def test_ocr_predict():
         {
             "text": "公司名称",
             "location": [(99, 19), (366, 19), (366, 75), (99, 75)],
-            "score": 0.828,
+            "score": 0.9974,
         },
         {
             "text": "英语学习",
             "location": [(599, 842), (814, 845), (814, 894), (599, 892)],
-            "score": 0.9393,
+            "score": 0.9983,
         },
     ]
     for pred, expected in zip(preds, expected):

--- a/tests/unit/landingai/test_predict.py
+++ b/tests/unit/landingai/test_predict.py
@@ -473,7 +473,9 @@ def test_predict_ocr_successful_expected_request_body(connect_mock):
 
     expected_predictions = [
         OcrPrediction(
-            text="test", location=[(598, 248), (818, 250), (818, 303), (598, 301)]
+            text="test",
+            location=[(598, 248), (818, 250), (818, 303), (598, 301)],
+            score=0.6326617002487183,
         )
     ]
 

--- a/tests/unit/landingai/test_predict.py
+++ b/tests/unit/landingai/test_predict.py
@@ -11,7 +11,7 @@ import responses
 from PIL import Image
 from responses.matchers import multipart_matcher
 
-from landingai.common import APIKey, InferenceMetadata
+from landingai.common import APIKey, InferenceMetadata, OcrPrediction
 from landingai.exceptions import (
     BadRequestError,
     ClientError,
@@ -457,3 +457,27 @@ def test_OcrPredictor_kwargs(kwargs):
     image = np.zeros((10, 10, 3), dtype=np.uint8)
     with pytest.raises(ValueError):
         predictor.predict(image, **kwargs)
+
+
+@patch("socket.socket")
+@responses.activate
+def test_predict_ocr_successful_expected_request_body(connect_mock):
+    # Fake a succesfull connection
+    sock_instance = connect_mock.return_value
+    sock_instance.connect_ex.return_value = 0
+
+    responses._add_from_file(file_path="tests/data/responses/test_ocr_predict.yaml")
+
+    img_path = "tests/data/images/ocr_test.png"
+    img = Image.open(img_path)
+
+    expected_predictions = [
+        OcrPrediction(
+            text="test", location=[(598, 248), (818, 250), (818, 303), (598, 301)]
+        )
+    ]
+
+    predictor = OcrPredictor(api_key="land_sk_something")
+    result = predictor.predict(img)
+
+    assert result == expected_predictions


### PR DESCRIPTION
Pr #173 broke `OcrPredictor` because the OCR response is not a dictionary but a list. I also noticed there are no unittests testing the OCR successful predictions and the OCR integration test was being skipped for some reason. This PR does a couple things:
1. Fixes the `OcrPredictor`
2. Adds a test for successful OCR prediction response
3. Unskips and fixes the OCR integration test
4. Fixes some OD integration tests due to some changes in the way we generate bounding boxes
5. Removes a `global` variable reference that is not used and I believe was introduced by mistake on PR #173 