### PR TITLE
fix: the initial_label parameter name sent to pictor is wrong

### DIFF
--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -549,7 +549,7 @@ def _upload_media(
         if isinstance(source, str)
         else source,
         "split": split,
-        "initialLabel": json.dumps(initial_label),
+        "initial_label": json.dumps(initial_label),
         "tags": json.dumps(tags),
         "metadata": json.dumps(metadata),
     }


### PR DESCRIPTION
Fix the `initial_label` parameter name sent to pictor. The correct parameter name is `initial_label` instead of `initialLabel`

Manually tested that the label upload succeeded. Here are some succeeded labeled images.

![Screenshot 2024-04-12 at 11 06 28 AM](https://github.com/landing-ai/landingai-python/assets/17306734/77672dd3-8376-4aee-b309-1a63d3df9c59)
