### PR TITLE
Restrict the version of urllib3 to avoid incompatible installs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3439,6 +3439,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4607,4 +4608,4 @@ snowflake = ["cryptography", "snowflake-connector-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "1ff8bc3b824a37ed62631e477051523c04ea91d94a50df1fb01d2e4d77ed0596"
+content-hash = "a4fcb47f680ca8ae41a29da995d63552a0d5d66a2b194f0ce734f2d84ab62c09"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ numpy = ">=1.21.0,<2.0.0"
 pillow = ">=9.0,<11.0"
 pydantic = { version = "1.*", extras = ["dotenv"] } # Version 2 has breaking changes (in particular to seetings)
 requests = "2.*"
+urllib3 = "^1.26.0"
 # snowflake-connector-python = "3.0.*"  # about 51MB (exclude transitive dependencies)
 bbox-visualizer = "^0.1.0"
 segmentation-mask-overlay = "^0.3.4"


### PR DESCRIPTION
Restrict the version of urllib3 to avoid incompatible installs
It helps avoid issues like https://community.landing.ai/c/ask-the-community/is-landing-ai-api-service-down