### PR TITLE
chore: add metadata and tags to media.ls()

### DIFF
--- a/landingai/data_management/client.py
+++ b/landingai/data_management/client.py
@@ -23,6 +23,7 @@ MEDIA_UPDATE_SPLIT = "media_update_split"
 GET_PROJECT_SPLIT = "get_project_split"
 GET_PROJECT = "get_project"
 GET_DEFECTS = "get_defects"
+GET_TAGS = "get_tags"
 GET_PROJECT_MODEL_INFO = "get_project_model_info"
 GET_FAST_TRAINING_EXPORT = "get_fast_training_export"
 
@@ -51,6 +52,11 @@ ROUTES = {
     GET_DEFECTS: {
         "root_url": "LANDING_API",
         "endpoint": "api/defect/defects",
+        "method": requests.get,
+    },
+    GET_TAGS: {
+        "root_url": "LANDING_API",
+        "endpoint": "api/{version}/tag/tags",
         "method": requests.get,
     },
     METADATA_ITEMS: {
@@ -289,3 +295,10 @@ class LandingLens:
         id_to_metadata = {v[0]: k for k, v in metadata_mapping.items()}
 
         return metadata_mapping, id_to_metadata
+
+    @lru_cache(maxsize=_LRU_CACHE_SIZE)
+    def get_tag_mappings(self, project_id: int) -> Dict[int, str]:
+        resp = self._api(GET_TAGS, params={"projectId": project_id})
+        tags_resp = resp.get("data", {})
+        tag_id_to_tag = {tag_field["id"]: tag_field["name"] for tag_field in tags_resp}
+        return tag_id_to_tag

--- a/landingai/data_management/media.py
+++ b/landingai/data_management/media.py
@@ -294,6 +294,8 @@ class Media:
         metadata_mapping, meta_id_to_metadata = self._client.get_metadata_mappings(
             project_id
         )
+        tag_id_to_tag = self._client.get_tag_mappings(project_id)
+
         metadata_filter_map: Dict[str, Any] = {}
         if metadata and len(metadata) > 0:
             metadata_filter_map = _metadata_to_filter(metadata, metadata_mapping)
@@ -324,6 +326,9 @@ class Media:
                 meta_id_to_metadata.get(int(k), None): v
                 for k, v in media["metadata"].items()
             }
+            media["tagIds"] = [
+                tag_id_to_tag.get(int(tag_id), None) for tag_id in media["tagIds"]
+            ]
 
         if len(medias) == self._media_max_page_size:
             _LOGGER.warning(f"fetched medias only up to {self._media_max_page_size}")
@@ -425,6 +430,7 @@ class _ListMediaRequestParams(PrettyPrintable):
             "uploadTime",
             "mediaStatus",
             "metadata",
+            "tagIds",
         ]
 
 


### PR DESCRIPTION
Description
---
* When listing medias, we don't return the metadata nor the tag values that the media contain.
* This PR adds these two fields on the media list output.

Example:

```
from landingai.data_management.media import Media
project_id = 88239681137029
media_client = Media(project_id, api_key)
media_client.ls()
```

Output:
```
{'medias': [{'id': 5236334,
   'mediaType': 'image',
   'srcType': 'user',
   'srcName': 'user_upload',
   'properties': {'width': 4200,
    'format': 'jpeg',
    'height': 2460,
    'orientation': 1},
   'name': 'cat_and_dog.jpg',
   'uploadTime': '2024-08-01T21:56:24.194Z',
   'mediaStatus': 'raw',
   'metadata': {},
   'tagIds': []},
  {'id': 5212814,
   'mediaType': 'image',
   'srcType': 'user',
   'srcName': 'user_upload',
   'properties': {'width': 413,
    'format': 'jpeg',
    'height': 640,
    'orientation': 1},
   'name': 'tomatoes.jpg',
   'uploadTime': '2024-07-04T23:25:13.535Z',
   'mediaStatus': 'approved',
   'metadata': {'vals': ['b', 'c'], 'foo': 'a'},
   'tagIds': ['foo', 'bar', 'not_clean']},
  {'id': 5172717,
   'mediaType': 'image',
   'srcType': 'user',
   'srcName': 'user_upload',
   'properties': {'width': 2048,
    'format': 'jpeg',
    'height': 2048,
    'orientation': 1},
   'name': 'img28.jpeg',
   'uploadTime': '2024-06-05T19:58:36.929Z',
   'mediaStatus': 'in_task',
   'metadata': {'vals': ['a'], 'is_optional': True},
   'tagIds': ['bar']}],
 'num_requested': 1000,
 'count': 3,
 'offset': 0,
 'limit': 1000}
```

