### PR TITLE
fix: retrieve media metadata values

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -33,7 +33,7 @@ YOUR_API_KEY = "land_sk_12345"
 YOUR_PROJECT_ID = 1190
 metadata_client = Metadata(YOUR_PROJECT_ID, YOUR_API_KEY)
 # Set three metadata values ('timestamp', 'country' and 'labeler') for images with IDs 123 and 124
-metadata_client.update(media_id=[123, 124], timestamp=12345, country="us", labeler="tom")
+metadata_client.update(media_ids=[123, 124], timestamp=12345, country="us", labeler="tom")
 # Output:
 # {
 #    project_id: 1190,

--- a/landingai/data_management/metadata.py
+++ b/landingai/data_management/metadata.py
@@ -99,7 +99,7 @@ class Metadata:
     def get(self, media_id: int) -> Dict[str, str]:
         """Return all the metadata associated with a given media."""
         resp = self._client._api(
-            METADATA_GET, params={"mediaId": media_id, "objectType": "media"}
+            METADATA_GET, params={"objectId": media_id, "objectType": "media"}
         )
         _, id_to_metadata = self._client.get_metadata_mappings(self._client._project_id)
         return {id_to_metadata[int(k)]: v for k, v in resp["data"].items()}

--- a/pdocs/user_guide/5_data_management.md
+++ b/pdocs/user_guide/5_data_management.md
@@ -33,7 +33,7 @@ YOUR_API_KEY = "land_sk_12345"
 YOUR_PROJECT_ID = 1190
 metadata_client = Metadata(YOUR_PROJECT_ID, YOUR_API_KEY)
 # Set three metadata values ('timestamp', 'country' and 'labeler') for images with IDs 123 and 124
-metadata_client.update(media_id=[123, 124], timestamp=12345, country="us", labeler="tom")
+metadata_client.update(media_ids=[123, 124], timestamp=12345, country="us", labeler="tom")
 # Output:
 # {
 #    project_id: 1190,


### PR DESCRIPTION
## Current Behavior

```python 
from landingai.data_management import Metadata
...
metadata_client = Metadata(YOUR_PROJECT_ID, YOUR_API_KEY)

metadata_client.get(13477948)
```
```
---------------------------------------------------------------------------
HttpError                                 Traceback (most recent call last)
[<ipython-input-4-c3949ab9e505>](https://localhost:8080/#) in <cell line: 1>()
----> 1 metadata_client.get(13477948)

1 frames
[/usr/local/lib/python3.10/dist-packages/landingai/data_management/client.py](https://localhost:8080/#) in _api(self, route_name, params, data, url_replacements)
    216                 _LOGGER.warning(f"Failed to parse error message into json: {e}")
    217                 error_message = resp.text
--> 218             raise HttpError(
    219                 "HTTP request to LandingLens server failed with "
    220                 f"code {resp.status_code}-{resp.reason} and error message: \n"

HttpError: HTTP request to LandingLens server failed with code 400-Bad Request and error message: 
Invalid parameter: 'objectId'. required

```

## Fix

```python
metadata_client.get(13477948)
```

```
INFO:landingai.data_management.client:Request URL: https://app.landing.ai/api/v1/object/metadata?objectId=13477948&objectType=media&projectId=***
{'country': 'bo'})
```



