### PR TITLE
Predict API was not exposed on the public documentation

### DIFF
--- a/docs/api/data_management.md
+++ b/docs/api/data_management.md
@@ -2,6 +2,8 @@
 
 ::: landingai.data_management.client
 
+::: landingai.data_management.dataset
+
 ::: landingai.data_management.label
 
 ::: landingai.data_management.media

--- a/docs/api/predict.md
+++ b/docs/api/predict.md
@@ -1,1 +1,11 @@
 ::: landingai.predict
+
+::: landingai.predict.cloud
+
+::: landingai.predict.edge
+
+::: landingai.predict.ocr
+
+::: landingai.predict.snowflake
+
+::: landingai.predict.utils


### PR DESCRIPTION
https://landing-ai.github.io/landingai-python/api/predict/ was empty
![image](https://github.com/user-attachments/assets/c230c8c3-ca80-4143-bcf2-7d4d947d3d31)
