### PR TITLE
feat: updated links to LandingLens documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ But most `FrameSet` operations were migrated to `Frame` class, so you can still 
 
 Below section shows you how to fix the backward incompatible changes when you upgrade the version to `0.1.0`.
 
-1. Generate your v2 API key from LandingLens. See [here](https://support.landing.ai/docs/api-key) for more information.
+1. Generate your v2 API key from LandingLens. See [here](https://landinglens.docs.landing.ai/api-key) for more information.
 2. The `api_secret` parameter is removed in the `Predictor` and `OcrPredictor` class. `api_key` is a named parameter now, which means you must specify the parameter name, i.e. `api_key`, if you want to pass it to a `Predictor` as an argument.
     See below code as an example:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The LandingLens Python library contains the LandingLens development library and 
 ## Documentation
 
 -  [LandingAI Python Library Docs](https://landing-ai.github.io/landingai-python/)
--  [LandingAI Support Center](https://support.landing.ai/)
+-  [LandingLens Documentation](https://landinglens.docs.landing.ai/)
 -  [LandingLens Walk-Through Video](https://www.youtube.com/watch?v=779kvo2dxb4)
 
 
@@ -69,7 +69,7 @@ For example, let's say we've created and deployed a model in LandingLens that de
 > If you don't have a LandingLens account, create one [here](https://app.landing.ai/). You will need to get an "endpoint ID" and "API key" from LandingLens in order to run inferences. Check our [Running Inferences / Getting Started](https://landing-ai.github.io/landingai-python/inferences/getting-started/).
 
 > [!NOTE]
-> Learn how to use LandingLens from our [Support Center]([https://support.landing.ai/docs/landinglens-workflow](https://support.landing.ai/landinglens/en)) and [Video Tutorial Library](https://support.landing.ai/docs/landinglens-workflow-2).
+> Learn how to use LandingLens from our [documentation](https://landinglens.docs.landing.ai/).
 > Need help with specific use cases? Post your questions in our [Community](https://community.landing.ai/home).
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ frame.resize(width=512, height=512) # (2)!
 frame.save_image("/tmp/resized-image.png") # (3)!
 ```
 
-1. We support several image file types. See the full list [here](https://support.landing.ai/docs/upload-images).
+1. We support several image file types. See the full list [here](https://landinglens.docs.landing.ai/upload-images).
 2. Resize the frame to 512x512p.
 3. Save the resized image to `/tmp/resized-image.png`.
 
@@ -64,7 +64,7 @@ For example, let's say we've created and deployed a model in LandingLens that de
 
 ???+ note
 
-    If you don't have a LandingLens account, create one [here](https://app.landing.ai/). Learn how to use LandingLens from our [Support Center]([https://support.landing.ai/docs/landinglens-workflow](https://support.landing.ai/landinglens/en)) and [Video Tutorial Library](https://support.landing.ai/docs/landinglens-workflow-2). Need help with specific use cases? Post your questions in our [Community](https://community.landing.ai/home).
+    If you don't have a LandingLens account, create one [here](https://app.landing.ai/). Learn how to use LandingLens from our [documentation](https://landinglens.docs.landing.ai/). Need help with specific use cases? Post your questions in our [Community](https://community.landing.ai/home).
 
 
 ???+ note

--- a/docs/inferences/docker-deployment.md
+++ b/docs/inferences/docker-deployment.md
@@ -1,11 +1,11 @@
 Running inferences with the standard `landingai.predict.Predictor` will send your image to LandingLens cloud, which is ideal if you don't want to worry about backend scalability, hardware provisioning, availability, etc. But this also adds some networking overhead that might limit how many inferences per second you can run.
 
-If you need to run several inferences per second, and you have your own cloud service or local machine, you might want to run inference using your own resources. For that, we provide **[Docker deployment](https://support.landing.ai/docs/docker-deploy)**, a Docker image with your LandingLens trained model embeded that you can run anywhere.
+If you need to run several inferences per second, and you have your own cloud service or local machine, you might want to run inference using your own resources. For that, we provide **[Docker deployment](https://landinglens.docs.landing.ai/landingedge/landingedge-overview)**, a Docker image with your LandingLens trained model embeded that you can run anywhere.
 
 
 ???+ note
 
-    You can get more details on how to set up and run the Docker deployment container locally or in your own cloud service in our [Support Center](https://support.landing.ai/docs/docker-deploy).
+    You can get more details on how to set up and run the Docker deployment container locally or in your own cloud service in our [documentation](https://landinglens.docs.landing.ai/landingedge/docker-deploy).
 
     Once you go through the Support Center guide, you will have the model running in a container, accessible in a specific host and port. The example below refers to these as `localhost` and `8000`, respectively.
 
@@ -37,4 +37,4 @@ The `EdgePredictor` class is a subclass of `Predictor`, so you can use it in the
 
 The time it takes to run the inference will vary according to the hardware where the Docker container is running (if you set it up to run on a GPU, for example, it will probably yield faster predictions).
 
-Check out the [Support Center](https://support.landing.ai/docs/docker-deploy) for more information on how to get a deployment license, run the Docker deployment with a a GPU, and more.
+Check out the [documentation](https://landinglens.docs.landing.ai/landingedge/docker-deploy) for more information on how to get a deployment license, run the Docker deployment with a a GPU, and more.

--- a/docs/inferences/getting-started.md
+++ b/docs/inferences/getting-started.md
@@ -3,7 +3,7 @@ Once you are ready to [acquire images](image-acquisition/image-acquisition.md), 
 
 ## Building your first model
 
-To run inferences using LandingLens, you must first build a model. If you didn't sign up before, visit https://app.landing.ai/, sign up for a free account and create a new project. If you are not familiar with LandingLens, you can find a lot of useful information in the [LandingLens support center](https://support.landing.ai/docs/landinglens-workflow).
+To run inferences using LandingLens, you must first build a model. If you didn't sign up before, visit https://app.landing.ai/, sign up for a free account and create a new project. If you are not familiar with LandingLens, you can find a lot of useful information in the [LandingLens documentation](https://landinglens.docs.landing.ai/).
 
 Long story short, after creating a project in LandingLens you will need to:
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -12,7 +12,7 @@ This section explains how to use the associated Python APIs to:
 
 Metadata is additional information you can attach to an image. Every image can be associated with multiple metadata. Each metadata is a key-value pair associated with an image, where key is the metadata name and value is a string that represents the information. For example, when you upload an image to LandingLens, you can add metadata like the country where the image was created, the timestamp when the image was created, etc.
 
-Metadata is useful when you need to manage hundreds or thousands of images in LandingLens or you need to collaborate with other team members to label datasets. For example, you can metadata to group certain types of images together (ex: images taken last week), then change their [split key](https://support.landing.ai/docs/datasets-and-splits) or create a [labeling task](https://support.landing.ai/landinglens/docs/agreement-based-labeling#send-labeling-tasks) for those images.
+Metadata is useful when you need to manage hundreds or thousands of images in LandingLens or you need to collaborate with other team members to label datasets. For example, you can metadata to group certain types of images together (ex: images taken last week), then change their [split key](https://landinglens.docs.landing.ai/splits) or create a [labeling task](hhttps://landinglens.docs.landing.ai/agreement-based-labeling) for those images.
 
 Use the `landingai.data_management.metadata.Metadata` API to manage metadata.
 
@@ -44,7 +44,7 @@ metadata_client.update(media_ids=[123, 124], timestamp=12345, country="us", labe
 
 ### Update Split Key for Images
 
-When managing hundreds or thousands of images on the platform, it can be more efficient to manage (add/update/remove) the [split key](https://support.landing.ai/docs/datasets-and-splits) programmatically. Use the `update_split_key()` function in `landingai.data_management.media.Media` to manage the the split value for images.
+When managing hundreds or thousands of images on the platform, it can be more efficient to manage (add/update/remove) the [split key](https://landinglens.docs.landing.ai/splits) programmatically. Use the `update_split_key()` function in `landingai.data_management.media.Media` to manage the the split value for images.
 
 **Example**
 
@@ -77,12 +77,12 @@ Use the `landingai.data_management.media.Media` API to upload images to a specif
 In addition to uploading images, the upload API supports the following features:
 1. Assign a split ('train'/'dev'/'test') to images. An empty string '' represents Unassigned and is the default.
 2. Upload labels along with images. The supported label files are:
-    * [Pascal VOC XML files](https://support.landing.ai/docs/upload-labeled-images-od) for Object Detection projects.
-    * [Segmentation mask files](https://support.landing.ai/docs/upload-labeled-images-seg) for Segmentation projects.
+    * [Pascal VOC XML files](https://landinglens.docs.landing.ai/upload-labeled-images-od) for Object Detection projects.
+    * [Segmentation mask files](https://landinglens.docs.landing.ai/upload-labeled-images-seg) for Segmentation projects.
     * A classification name (string) for Classification projects.
 3. Attach additional metadata (key-value pairs) to images.
 
-for more information, go [here](https://support.landing.ai/landinglens/docs/uploading#upload-images-with-split-and-label-information).
+For more information about uploading images, go [here](https://landinglens.docs.landing.ai/upload-images).
 
 
 ### Upload Segmentation Masks

--- a/examples/capture-service/README.md
+++ b/examples/capture-service/README.md
@@ -23,7 +23,7 @@ The program captures frames from the video feed every few seconds, and then runs
 ## Customize the Example
 
 1. Set up a camera that exposes an RTSP URL to your network (your local intranet). If you're not sure if the RTSP URL is working, learn how to test it in this [article](https://support.ipconfigure.com/hc/en-us/articles/115005588503-Using-VLC-to-test-camera-stream).
-2. Train a model in LandingLens, and deploy it to an endpoint via [Cloud Deployment](https://support.landing.ai/landinglens/docs/cloud-deployment).
+2. Train a model in LandingLens, and deploy it to an endpoint via [Cloud Deployment](https://landinglens.docs.landing.ai/cloud-deployment).
 3. Get the `endpoint id`, `api key` and `api secret` from LandingLens.
 4. Open the file `examples/capture-service/run.py`, and update the following with your information: `api_key`, `endpoint_id` and `stream_url`.
 

--- a/examples/capture-service/run.py
+++ b/examples/capture-service/run.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             cloud_sky_model = EdgePredictor()
         except ConnectionError:
             _LOGGER.error(
-                f"""Failed to connect to the local LandingLens docker inference service. Have you launched the LandingLens container? If not please read the guide here (https://support.landing.ai/docs/docker-deploy)\nOnce you have installed it and obtained a license, run:
+                f"""Failed to connect to the local LandingLens docker inference service. Have you launched the LandingLens container? If not please read the guide here (https://landinglens.docs.landing.ai/landingedge/docker-deploy)\nOnce you have installed it and obtained a license, run:
                 docker run -p 8000:8000 --rm --name landingedge\\
                 -e LANDING_LICENSE_KEY=YOUR_LICENSE_KEY  \\
                 public.ecr.aws/landing-ai/deploy:latest \\

--- a/landingai/common.py
+++ b/landingai/common.py
@@ -36,7 +36,7 @@ class APIKey(BaseSettings):
         """Check if the API key is a v2 key."""
         if not key.startswith("land_sk_"):
             raise InvalidApiKeyError(
-                f"API key (v2) must start with 'land_sk_' prefix, but it's {key}. See https://support.landing.ai/docs/api-key for more information."
+                f"API key (v2) must start with 'land_sk_' prefix, but it's {key}. See https://landinglens.docs.landing.ai/api-key for more information."
             )
         return key
 
@@ -69,7 +69,7 @@ class ClassificationPrediction(Prediction):
     label_index: int
     """The predicted label index.
     A label index is an unique integer that identifies a label in your label book.
-    For more information, see https://support.landing.ai/docs/manage-label-book.
+    For more information, see https://landinglens.docs.landing.ai/manage-label-book.
     """
 
 

--- a/pdocs/user_guide/1_concepts.md
+++ b/pdocs/user_guide/1_concepts.md
@@ -17,10 +17,10 @@ This section explains important high-level concepts that will help you better us
 
 ### Model Deployment Options
 
-Before using this library for inference, you need train your model in LandingLens and [deploy it](https://support.landing.ai/docs/deployment-options).
+Before using this library for inference, you need train your model in LandingLens and [deploy it](https://landinglens.docs.landing.ai/deployment-options).
 
 This library supports two deployment options:
-- [Cloud Deployment](https://support.landing.ai/landinglens/docs/cloud-deployment)
+- [Cloud Deployment](https://landinglens.docs.landing.ai/cloud-deployment)
 - [Edge Deployment] (support coming soon...)
 
 The easiest way to get started is using a Cloud Deployment.

--- a/pdocs/user_guide/2_credentials.md
+++ b/pdocs/user_guide/2_credentials.md
@@ -1,6 +1,6 @@
 ## Manage API Credentials
 
-If you send images to an endpoint through API (Cloud Deployment), you must add your API Key to the API call. You can generate the API Key in LandingLens. This API key is also known as API key v2. See [here](https://support.landing.ai/docs/api-key-and-api-secret) for more information.
+If you send images to an endpoint through API (Cloud Deployment), you must add your API Key to the API call. You can generate the API Key in LandingLens. This API key is also known as API key v2. See [here](https://landinglens.docs.landing.ai/api-key) for more information.
 
 Once you have generated the API key, here are three ways to configure your API Key, ordered by the priority in which they are loaded:
 
@@ -16,7 +16,7 @@ Once you have generated the API key, here are three ways to configure your API K
 
 In the past, LandingLens supports generating a key and secret pair, which is known as API key v1. This key is no longer supported in `landingai` Python package in version `0.1.0` and above.
 
-See [here](https://support.landing.ai/docs/api-key) for how to generate API v2 key.
+See [here](https://landinglens.docs.landing.ai/api-key) for how to generate API v2 key.
 
 ### FAQ
 

--- a/pdocs/user_guide/5_data_management.md
+++ b/pdocs/user_guide/5_data_management.md
@@ -12,7 +12,7 @@ This section explains how to use the associated Python APIs to:
 
 Metadata is additional information you can attach to an image. Every image can be associated with multiple metadata. Each metadata is a key-value pair associated with an image, where key is the metadata name and value is a string that represents the information. For example, when you upload an image to LandingLens, you can add metadata like the country where the image was created, the timestamp when the image was created, etc.
 
-Metadata is useful when you need to manage hundreds or thousands of images in LandingLens or you need to collaborate with other team members to label datasets. For example, you can metadata to group certain types of images together (ex: images taken last week), then change their [split key](https://support.landing.ai/docs/splits) or create a [labeling task](https://support.landing.ai/docs/agreement-based-labeling) for those images.
+Metadata is useful when you need to manage hundreds or thousands of images in LandingLens or you need to collaborate with other team members to label datasets. For example, you can metadata to group certain types of images together (ex: images taken last week), then change their [split key](https://landinglens.docs.landing.ai/splits) or create a [labeling task](https://landinglens.docs.landing.ai/agreement-based-labeling) for those images.
 
 Use the `landingai.data_management.metadata.Metadata` API to manage metadata.
 
@@ -44,7 +44,7 @@ metadata_client.update(media_ids=[123, 124], timestamp=12345, country="us", labe
 
 ### Update Split Key for Images
 
-When managing hundreds or thousands of images on the platform, it can be more efficient to manage (add/update/remove) the [split key](https://support.landing.ai/docs/splits) programmatically. Use the `update_split_key()` function in `landingai.data_management.media.Media` to manage the the split value for images.
+When managing hundreds or thousands of images on the platform, it can be more efficient to manage (add/update/remove) the [split key](https://landinglens.docs.landing.ai/splits) programmatically. Use the `update_split_key()` function in `landingai.data_management.media.Media` to manage the the split value for images.
 
 **Example**
 
@@ -77,8 +77,8 @@ Use the `landingai.data_management.media.Media` API to upload images to a specif
 In addition to uploading images, the upload API supports the following features:
 1. Assign a split ('train'/'dev'/'test') to images. An empty string '' represents Unassigned and is the default.
 2. Upload labels along with images. The supported label files are:
-    * [Pascal VOC XML files](https://support.landing.ai/docs/upload-labeled-images-od) for Object Detection projects.
-    * [Segmentation mask files](https://support.landing.ai/docs/upload-labeled-images-seg) for Segmentation projects.
+    * [Pascal VOC XML files](https://landinglens.docs.landing.ai/upload-labeled-images-od) for Object Detection projects.
+    * [Segmentation mask files](https://landinglens.docs.landing.ai/upload-labeled-images-seg) for Segmentation projects.
     * A classification name (string) for Classification projects.
 3. Attach additional metadata (key-value pairs) to images.
 


### PR DESCRIPTION
The links to the LandingLens docs still pointed to support.landing.ai. Updated these to point to https://landinglens.docs.landing.ai/.

See https://app.asana.com/1/504311096896991/project/1203963067800274/task/1213411714740378?focus=true