### PR TITLE
fix(tests): read integration test API key from LANDINGAI_API_KEY secret

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -44,6 +44,10 @@ jobs:
       run: |
         poetry run mypy landingai
     - name: Test with pytest
+      env:
+        # Not available to pull requests from forks; the integration tests that
+        # need it skip themselves when it is empty.
+        LANDINGAI_API_KEY: ${{ secrets.LANDINGAI_API_KEY }}
       run: |
         poetry run pytest -v tests
 

--- a/tests/integration/landingai/test_predict_e2e.py
+++ b/tests/integration/landingai/test_predict_e2e.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 import numpy as np
@@ -9,7 +10,17 @@ from landingai.common import InferenceMetadata
 from landingai.predict import OcrPredictor, Predictor
 from landingai.visualize import overlay_predictions
 
-_API_KEY = "land_sk_aMemWbpd41yXnQ0tXvZMh59ISgRuKNRKjJEIUHnkiH32NBJAwf"
+# These tests call live LandingLens endpoints, so they need a real API key.
+# It is read from the LANDINGAI_API_KEY environment variable, which CI populates
+# from the repository secret of the same name. Secrets are not exposed to
+# workflow runs triggered by pull requests from forks, so skip instead of
+# failing when the key is absent.
+_API_KEY = os.environ.get("LANDINGAI_API_KEY", "")
+
+pytestmark = pytest.mark.skipif(
+    not _API_KEY,
+    reason="LANDINGAI_API_KEY is not set; skipping tests that call live endpoints.",
+)
 
 _EXPECTED_VP_PREDS = [
     {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+# Both cases are cleared because pydantic-settings matches env vars
+# case-insensitively, and the tests below set the lowercase spelling.
+_API_CREDENTIAL_ENV_VARS = (
+    "LANDINGAI_API_KEY",
+    "landingai_api_key",
+    "LANDINGAI_API_SECRET",
+    "landingai_api_secret",
+)
+
+
+@pytest.fixture(autouse=True)
+def unset_api_credential_env_vars(monkeypatch):
+    """Isolate unit tests from API credentials in the ambient environment.
+
+    CI exports LANDINGAI_API_KEY so the integration tests can call live
+    endpoints. Environment variables take precedence over .env files, so
+    without this the credential-loading tests would read the real key instead
+    of the one they set up, and the tests asserting that an invalid or missing
+    key raises would silently find a valid one.
+
+    Tests that need a credential set it themselves after this fixture runs.
+    """
+    for var in _API_CREDENTIAL_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
## What

The e2e predict tests carried a hardcoded LandingLens API key at the top of
`tests/integration/landingai/test_predict_e2e.py`. This reads it from the
`LANDINGAI_API_KEY` environment variable instead, populated in CI from the
repository secret of the same name.

## Why

CI has been red since the hardcoded key stopped resolving to a user record —
all five live-endpoint tests failed with `401 UNAUTHORIZED`
(`Failed to find user record with apiKey: land_sk_aMemW***`), which cancelled
the whole 12-job matrix and blocked `Release`. With the key in source there was
no way to rotate it without a code change.

## Fork PRs

Repository secrets are not exposed to workflow runs triggered by pull requests
from forks, and this repo is public with 59 of them. So the tests skip
themselves when the key is empty rather than failing with a 401 that external
contributors cannot act on:

```
5 skipped   # LANDINGAI_API_KEY unset
5 passed    # LANDINGAI_API_KEY set
```

Both paths verified locally against the live endpoints.