### PR TITLE
ci: replace retired macos-12 runner with macos-26

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
+    - name: Install ffmpeg
+      # imageio-ffmpeg 0.5.1 bundles no arm64 macOS binary, so the runner needs a system ffmpeg
+      if: runner.os == 'macOS'
+      run: brew install ffmpeg
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+        os: [ ubuntu-22.04, windows-2022, macos-26 ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub retired the `macos-12` hosted runner image, so the macOS jobs in the CI matrix have been queuing forever and never running (see the stuck `macos-12` jobs on recent CI runs).

This pins the matrix to `macos-26`, the latest stable numbered macOS image.

Note: `macos-12` was Intel (x86_64); `macos-26` runs on Apple Silicon (arm64), so macOS tests now exercise arm64 wheels/dependencies.