### PR TITLE
ci: use built-in GITHUB_TOKEN for Release checkout instead of expired PAT

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -60,6 +60,8 @@ jobs:
     # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):') && !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/setup-python@v4
         with:
@@ -73,8 +75,6 @@ jobs:
         run: poetry config virtualenvs.in-project true
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_TOKEN }}
       - name: setup git config
         run: |
           git config user.name "GitHub Actions Bot"


### PR DESCRIPTION
## Problem

The Release job has been failing at the **Checkout code** step (e.g. [run 31812690691](https://github.com/landing-ai/landingai-python/actions/runs/31812690691)):

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Checkout authenticated with the `GH_TOKEN` secret — a PAT last updated on 2023-05-30 that has since expired/been revoked, so git falls back to prompting for credentials, which is disabled in CI.

## Fix

Use the default workflow token instead of the PAT, granting the Release job `permissions: contents: write` so it can still push the version-bump commit. This removes the dependency on a PAT that needs periodic rotation.

**Note:** pushes made with the built-in token don't trigger other workflows, but that's fine here — the version-bump commit already carries `[skip ci]` in its message, so it was never meant to re-trigger CI.

## Caveats

- If `main` has branch protection that blocks the GitHub Actions bot from pushing, the `git push` in **Bump up version** would still fail — in that case a GitHub App token would be the PAT-free alternative.
